### PR TITLE
feat: add admin post list query params (#13)

### DIFF
--- a/api-spec.md
+++ b/api-spec.md
@@ -1,5 +1,35 @@
 # Server API Spec
 
+## Admin Posts
+
+### GET `/api/admin/posts`
+
+Auth: `requireAdmin`
+
+Query Parameters:
+
+| Param          | Type    | Default      | Description                            |
+|----------------|---------|--------------|----------------------------------------|
+| page           | number  | 1            | 페이지 번호                             |
+| limit          | number  | 20           | 페이지당 개수 (max 100)                 |
+| status         | string  | -            | `draft` \| `published` \| `archived`   |
+| visibility     | string  | -            | `public` \| `private`                  |
+| categoryId     | number  | -            | 카테고리 필터                            |
+| tagSlug        | string  | -            | 태그 slug 필터                          |
+| q              | string  | -            | 키워드 검색 (title, contentMd)          |
+| includeDeleted | boolean | false        | 소프트 삭제된 글 포함 여부                |
+| sort           | string  | created_at   | 정렬 기준 (`created_at` \| `published_at`) |
+| order          | string  | desc         | 정렬 방향 (`asc` \| `desc`)             |
+
+Response `200`:
+
+```json
+{
+  "data": [PostDetail],
+  "meta": { "page": 1, "limit": 20, "total": 100, "totalPages": 5 }
+}
+```
+
 ## Guestbook
 
 ### POST `/api/guestbook`

--- a/src/routes/posts/post.route.ts
+++ b/src/routes/posts/post.route.ts
@@ -5,6 +5,7 @@ import {
   PostSlugParamSchema,
   PostIdParamSchema,
   PostListQuerySchema,
+  AdminPostListQuerySchema,
   CreatePostBodySchema,
   UpdatePostBodySchema,
   PostListResponseSchema,
@@ -126,7 +127,7 @@ export function createAdminPostRoute(
           summary: "Get all posts (Admin)",
           description:
             "모든 게시글 목록을 조회합니다. status, visibility, deleted 상태와 무관하게 조회 가능합니다.",
-          querystring: PostListQuerySchema,
+          querystring: AdminPostListQuerySchema,
           response: {
             200: PostListResponseSchema,
           },

--- a/src/routes/posts/post.schema.ts
+++ b/src/routes/posts/post.schema.ts
@@ -53,6 +53,19 @@ export const PostListQuerySchema = z.object({
   includeDeleted: z.coerce.boolean().optional().default(false),
 });
 
+export const AdminPostListQuerySchema = z.object({
+  page: z.coerce.number().int().positive().optional().default(1),
+  limit: z.coerce.number().int().positive().max(100).optional().default(20),
+  categoryId: z.coerce.number().int().positive().optional(),
+  tagSlug: z.string().min(1).optional(),
+  q: z.string().min(1).max(200).optional(),
+  status: z.enum(["draft", "published", "archived"]).optional(),
+  visibility: z.enum(["public", "private"]).optional(),
+  sort: z.enum(["published_at", "created_at"]).optional().default("created_at"),
+  order: z.enum(["asc", "desc"]).optional().default("desc"),
+  includeDeleted: z.coerce.boolean().optional().default(false),
+});
+
 /**
  * Request Body Schemas
  */
@@ -139,5 +152,6 @@ export const PostDetailWithNavigationResponseSchema = z.object({
 export type PostSlugParam = z.infer<typeof PostSlugParamSchema>;
 export type PostIdParam = z.infer<typeof PostIdParamSchema>;
 export type PostListQuery = z.infer<typeof PostListQuerySchema>;
+export type AdminPostListQuery = z.infer<typeof AdminPostListQuerySchema>;
 export type CreatePostBody = z.infer<typeof CreatePostBodySchema>;
 export type UpdatePostBody = z.infer<typeof UpdatePostBodySchema>;


### PR DESCRIPTION
## Summary
Closes #13

- `AdminPostListQuerySchema` 신규 생성 (admin 전용 기본값: limit=20, sort=created_at)
- Admin 라우트에서 기존 `PostListQuerySchema` → `AdminPostListQuerySchema` 교체
- `api-spec.md`에 GET /api/admin/posts 쿼리 파라미터 스펙 문서화

## Changes
- **api-spec.md**: Admin Posts 섹션 추가 (쿼리 파라미터 10개 문서화)
- **src/routes/posts/post.schema.ts**: `AdminPostListQuerySchema` + `AdminPostListQuery` 타입 추가
- **src/routes/posts/post.route.ts**: admin GET / 라우트에서 `AdminPostListQuerySchema` 사용

## Test plan
- [ ] `GET /api/admin/posts` 기본 호출 시 limit=20, sort=created_at 확인
- [ ] `GET /api/admin/posts?status=draft` 필터링 동작 확인
- [ ] `GET /api/admin/posts?includeDeleted=true` 소프트 삭제 포함 확인
- [ ] `GET /api/admin/posts?categoryId=1&tagSlug=test` 복합 필터 확인
- [ ] Public `GET /api/posts` 기존 동작 변경 없음 확인
