### PR TITLE
feat: add GET /api/assets list endpoint with pagination

### DIFF
--- a/src/routes/assets/asset.route.ts
+++ b/src/routes/assets/asset.route.ts
@@ -3,6 +3,8 @@ import { ZodTypeProvider } from "fastify-type-provider-zod";
 import { z } from "zod";
 import {
   assetIdParamSchema,
+  assetListQuerySchema,
+  assetListResponseSchema,
   uploadAssetsResponseSchema,
   assetResponseSchema,
   errorResponseSchema,
@@ -61,6 +63,30 @@ export function createAssetRoute(
         return reply.status(201).send({
           assets,
         });
+      },
+    );
+
+    // GET /api/assets - Asset 목록 조회 (Admin)
+    typedFastify.get(
+      "/",
+      {
+        preHandler: requireAdmin(adminService),
+        schema: {
+          tags: ["assets"],
+          summary: "Get asset list",
+          description:
+            "에셋 목록을 페이지네이션으로 조회합니다. Admin 권한이 필요합니다.",
+          querystring: assetListQuerySchema,
+          response: {
+            200: assetListResponseSchema,
+            403: errorResponseSchema,
+          },
+        },
+      },
+      async (request, reply) => {
+        const result = await assetService.getAssetList(request.query);
+
+        return reply.status(200).send(result);
       },
     );
 

--- a/src/routes/assets/asset.schema.ts
+++ b/src/routes/assets/asset.schema.ts
@@ -1,4 +1,5 @@
 import { z } from "zod";
+import { PaginationMetaSchema } from "@src/schemas/common";
 
 /**
  * Asset 응답 스키마
@@ -13,6 +14,13 @@ export const assetResponseSchema = z.object({
 });
 
 /**
+ * Asset 목록 응답 아이템 스키마 (createdAt 포함)
+ */
+export const assetListItemSchema = assetResponseSchema.extend({
+  createdAt: z.string(),
+});
+
+/**
  * Asset 업로드 응답 (단일)
  */
 export const uploadAssetResponseSchema = assetResponseSchema;
@@ -22,6 +30,22 @@ export const uploadAssetResponseSchema = assetResponseSchema;
  */
 export const uploadAssetsResponseSchema = z.object({
   assets: z.array(assetResponseSchema),
+});
+
+/**
+ * Asset 목록 쿼리 스키마
+ */
+export const assetListQuerySchema = z.object({
+  page: z.coerce.number().int().min(1).default(1),
+  limit: z.coerce.number().int().min(1).max(100).default(20),
+});
+
+/**
+ * Asset 목록 응답 스키마
+ */
+export const assetListResponseSchema = z.object({
+  data: z.array(assetListItemSchema),
+  meta: PaginationMetaSchema,
 });
 
 /**


### PR DESCRIPTION
## 개요

`GET /api/assets` 에셋 목록 엔드포인트를 추가합니다. Admin 인증 필수, 페이지네이션 지원.

## 변경 사항

- **asset.schema.ts**: `assetListItemSchema` (createdAt 포함), `assetListQuerySchema`, `assetListResponseSchema` 추가
- **asset.service.ts**: `getAssetList()` 메서드 추가 — COUNT 쿼리 + 페이지네이션 SELECT, `createdAt` DESC 정렬
- **asset.route.ts**: `GET /` 라우트 등록 (Admin preHandler, querystring 검증)

## API 스펙

```
GET /api/assets          (Auth: Admin)

Query: page (default: 1), limit (default: 20, max: 100)

Response 200:
{
  "data": [{ "id": 1, "url": "/uploads/...", "mimeType": "image/png", "sizeBytes": 12345, "width": 800, "height": 600, "createdAt": "ISO" }],
  "meta": { "page": 1, "limit": 20, "total": 50, "totalPages": 3 }
}
```

Closes #15
