### PR TITLE
docs: Workflow 섹션을 /dev-pipeline 직접 참조로 변경

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -52,4 +52,4 @@ type NewPost = typeof posts.$inferInsert;
 
 ## Workflow
 
-Follow root `CLAUDE.md` task rules. Records go in `docs/server/`.
+`/dev-pipeline`이 전체 사이클을 관리. Records go in `docs/server/`.


### PR DESCRIPTION
## Summary

- Workflow 섹션에서 `Follow root CLAUDE.md task rules` → `/dev-pipeline이 전체 사이클을 관리`로 변경
- root CLAUDE.md의 Task Rules 슬림화에 맞춰 스킬 직접 참조로 전환

🤖 Generated with [Claude Code](https://claude.com/claude-code)