### PR TITLE
feat: auth system (#31)

### DIFF
--- a/src/hooks/auth.hook.ts
+++ b/src/hooks/auth.hook.ts
@@ -14,13 +14,12 @@ export async function requireAuth(request: FastifyRequest) {
 
 /**
  * 선택적 인증 확인 (인증되지 않아도 통과)
- * request.user가 있으면 인증된 상태, 없으면 비인증 상태
+ * 인증된 경우 request.user에 OAuthAccount, 미인증 시 null로 설정
  */
 export async function optionalAuth(request: FastifyRequest) {
-  // request.user가 있으면 인증된 상태, 없어도 통과
-  request.log.debug(
-    request.user ? "Authenticated request" : "Unauthenticated request",
-  );
+  if (!request.user) {
+    request.user = null;
+  }
 }
 
 /**

--- a/src/plugins/passport.ts
+++ b/src/plugins/passport.ts
@@ -30,129 +30,135 @@ const passportPlugin: FastifyPluginAsync = async (fastify) => {
     return account || null;
   });
 
-  // Google OAuth Strategy
-  fastifyPassport.use(
-    "google",
-    new GoogleStrategy(
-      {
-        clientID: env.GOOGLE_CLIENT_ID,
-        clientSecret: env.GOOGLE_CLIENT_SECRET,
-        callbackURL: "/api/auth/google/callback",
-      },
-      async (_accessToken, _refreshToken, profile, done) => {
-        try {
-          const {
-            name,
-            email: googleEmail,
-            picture,
-          } = profile._json as {
-            name: string;
-            email: string;
-            picture: string;
-          };
+  // Google OAuth Strategy (only register if credentials are configured)
+  if (env.GOOGLE_CLIENT_ID && env.GOOGLE_CLIENT_SECRET) {
+    fastifyPassport.use(
+      "google",
+      new GoogleStrategy(
+        {
+          clientID: env.GOOGLE_CLIENT_ID,
+          clientSecret: env.GOOGLE_CLIENT_SECRET,
+          callbackURL: "/api/auth/google/callback",
+        },
+        async (_accessToken, _refreshToken, profile, done) => {
+          try {
+            const {
+              name,
+              email: googleEmail,
+              picture,
+            } = profile._json as {
+              name: string;
+              email: string;
+              picture: string;
+            };
 
-          const googleId = profile.id;
+            const googleId = profile.id;
 
-          // 기존 계정 찾기
-          const [existingAccount] = await db
-            .select()
-            .from(oauthAccountTable)
-            .where(
-              and(
-                eq(oauthAccountTable.provider, "google"),
-                eq(oauthAccountTable.providerUserId, googleId),
-              ),
-            )
-            .limit(1);
+            // 기존 계정 찾기
+            const [existingAccount] = await db
+              .select()
+              .from(oauthAccountTable)
+              .where(
+                and(
+                  eq(oauthAccountTable.provider, "google"),
+                  eq(oauthAccountTable.providerUserId, googleId),
+                ),
+              )
+              .limit(1);
 
-          if (existingAccount) {
-            return done(null, existingAccount);
+            if (existingAccount) {
+              return done(null, existingAccount);
+            }
+
+            // 새 계정 생성
+            const [result] = await db.insert(oauthAccountTable).values({
+              provider: "google",
+              providerUserId: googleId,
+              email: googleEmail,
+              displayName: name,
+              avatarUrl: picture,
+            });
+
+            const [newAccount] = await db
+              .select()
+              .from(oauthAccountTable)
+              .where(eq(oauthAccountTable.id, Number(result.insertId)))
+              .limit(1);
+
+            return done(null, newAccount);
+          } catch (error) {
+            return done(error as Error);
           }
+        },
+      ),
+    );
+    fastify.log.info("[Passport] Google strategy registered");
+  }
 
-          // 새 계정 생성
-          const [result] = await db.insert(oauthAccountTable).values({
-            provider: "google",
-            providerUserId: googleId,
-            email: googleEmail,
-            displayName: name,
-            avatarUrl: picture,
-          });
+  // GitHub OAuth Strategy (only register if credentials are configured)
+  if (env.GITHUB_CLIENT_ID && env.GITHUB_CLIENT_SECRET) {
+    fastifyPassport.use(
+      "github",
+      new GitHubStrategy(
+        {
+          clientID: env.GITHUB_CLIENT_ID,
+          clientSecret: env.GITHUB_CLIENT_SECRET,
+          callbackURL: "/api/auth/github/callback",
+        },
+        async (_accessToken, _refreshToken, profile, done) => {
+          try {
+            const {
+              avatar_url: url,
+              name,
+              login,
+            } = profile._json as {
+              login: string;
+              avatar_url: string;
+              name: string;
+            };
 
-          const [newAccount] = await db
-            .select()
-            .from(oauthAccountTable)
-            .where(eq(oauthAccountTable.id, Number(result.insertId)))
-            .limit(1);
+            const githubId = profile.id;
 
-          return done(null, newAccount);
-        } catch (error) {
-          return done(error as Error);
-        }
-      },
-    ),
-  );
+            // 기존 계정 찾기
+            const [existingAccount] = await db
+              .select()
+              .from(oauthAccountTable)
+              .where(
+                and(
+                  eq(oauthAccountTable.provider, "github"),
+                  eq(oauthAccountTable.providerUserId, githubId),
+                ),
+              )
+              .limit(1);
 
-  // GitHub OAuth Strategy
-  fastifyPassport.use(
-    "github",
-    new GitHubStrategy(
-      {
-        clientID: env.GITHUB_CLIENT_ID,
-        clientSecret: env.GITHUB_CLIENT_SECRET,
-        callbackURL: "/api/auth/github/callback",
-      },
-      async (_accessToken, _refreshToken, profile, done) => {
-        try {
-          const {
-            avatar_url: url,
-            name,
-            login,
-          } = profile._json as {
-            login: string;
-            avatar_url: string;
-            name: string;
-          };
+            if (existingAccount) {
+              return done(null, existingAccount);
+            }
 
-          const githubId = profile.id;
+            // 새 계정 생성
+            const [result] = await db.insert(oauthAccountTable).values({
+              provider: "github",
+              providerUserId: githubId,
+              email: null,
+              displayName: name ?? login,
+              avatarUrl: url,
+            });
 
-          // 기존 계정 찾기
-          const [existingAccount] = await db
-            .select()
-            .from(oauthAccountTable)
-            .where(
-              and(
-                eq(oauthAccountTable.provider, "github"),
-                eq(oauthAccountTable.providerUserId, githubId),
-              ),
-            )
-            .limit(1);
+            const [newAccount] = await db
+              .select()
+              .from(oauthAccountTable)
+              .where(eq(oauthAccountTable.id, Number(result.insertId)))
+              .limit(1);
 
-          if (existingAccount) {
-            return done(null, existingAccount);
+            return done(null, newAccount);
+          } catch (error) {
+            return done(error as Error);
           }
-
-          // 새 계정 생성
-          const [result] = await db.insert(oauthAccountTable).values({
-            provider: "github",
-            providerUserId: githubId,
-            email: null,
-            displayName: name ?? login,
-            avatarUrl: url,
-          });
-
-          const [newAccount] = await db
-            .select()
-            .from(oauthAccountTable)
-            .where(eq(oauthAccountTable.id, Number(result.insertId)))
-            .limit(1);
-
-          return done(null, newAccount);
-        } catch (error) {
-          return done(error as Error);
-        }
-      },
-    ),
-  );
+        },
+      ),
+    );
+    fastify.log.info("[Passport] GitHub strategy registered");
+  }
 
   fastify.log.info("[Passport] Plugin registered");
 };

--- a/src/routes/auth/auth.route.ts
+++ b/src/routes/auth/auth.route.ts
@@ -22,39 +22,43 @@ export function createAuthRoute(
   const authRoute: FastifyPluginAsync = async (fastify: FastifyInstance) => {
     const typedFastify = fastify.withTypeProvider<ZodTypeProvider>();
 
-    // ===== OAuth Routes =====
+    // ===== OAuth Routes (registered only when credentials are configured) =====
 
     // Google OAuth
-    fastify.get(
-      "/google",
-      fastifyPassport.authenticate("google", {
-        scope: ["email", "profile"],
-      }),
-    );
+    if (env.GOOGLE_CLIENT_ID && env.GOOGLE_CLIENT_SECRET) {
+      fastify.get(
+        "/google",
+        fastifyPassport.authenticate("google", {
+          scope: ["email", "profile"],
+        }),
+      );
 
-    fastify.get(
-      "/google/callback",
-      fastifyPassport.authenticate("google", {
-        successRedirect: new URL(env.LOGIN_SUCCESS_PATH, env.CLIENT_URL).href,
-        failureRedirect: new URL(env.LOGIN_FAILURE_PATH, env.CLIENT_URL).href,
-      }),
-    );
+      fastify.get(
+        "/google/callback",
+        fastifyPassport.authenticate("google", {
+          successRedirect: new URL(env.LOGIN_SUCCESS_PATH, env.CLIENT_URL).href,
+          failureRedirect: new URL(env.LOGIN_FAILURE_PATH, env.CLIENT_URL).href,
+        }),
+      );
+    }
 
     // GitHub OAuth
-    fastify.get(
-      "/github",
-      fastifyPassport.authenticate("github", {
-        scope: ["user:email"],
-      }),
-    );
+    if (env.GITHUB_CLIENT_ID && env.GITHUB_CLIENT_SECRET) {
+      fastify.get(
+        "/github",
+        fastifyPassport.authenticate("github", {
+          scope: ["user:email"],
+        }),
+      );
 
-    fastify.get(
-      "/github/callback",
-      fastifyPassport.authenticate("github", {
-        successRedirect: new URL(env.LOGIN_SUCCESS_PATH, env.CLIENT_URL).href,
-        failureRedirect: new URL(env.LOGIN_FAILURE_PATH, env.CLIENT_URL).href,
-      }),
-    );
+      fastify.get(
+        "/github/callback",
+        fastifyPassport.authenticate("github", {
+          successRedirect: new URL(env.LOGIN_SUCCESS_PATH, env.CLIENT_URL).href,
+          failureRedirect: new URL(env.LOGIN_FAILURE_PATH, env.CLIENT_URL).href,
+        }),
+      );
+    }
 
     // ===== Admin Auth Routes =====
 

--- a/src/shared/env.ts
+++ b/src/shared/env.ts
@@ -42,13 +42,13 @@ const envSchema = z
     LOGIN_SUCCESS_PATH: z.string().min(1),
     LOGIN_FAILURE_PATH: z.string().min(1),
 
-    // Google OAuth
-    GOOGLE_CLIENT_ID: z.string().min(1),
-    GOOGLE_CLIENT_SECRET: z.string().min(1),
+    // Google OAuth (optional — omit to disable Google login)
+    GOOGLE_CLIENT_ID: z.string().default(""),
+    GOOGLE_CLIENT_SECRET: z.string().default(""),
 
-    // GitHub OAuth
-    GITHUB_CLIENT_ID: z.string().min(1),
-    GITHUB_CLIENT_SECRET: z.string().min(1),
+    // GitHub OAuth (optional — omit to disable GitHub login)
+    GITHUB_CLIENT_ID: z.string().default(""),
+    GITHUB_CLIENT_SECRET: z.string().default(""),
   })
   .transform((data) => {
     // CLIENT_URL 자동 생성

--- a/src/types/fastify.d.ts
+++ b/src/types/fastify.d.ts
@@ -10,8 +10,9 @@ declare module "fastify" {
     admin?: AdminResponse;
 
     /**
-     * OAuth 로그인 사용자 정보 (Passport에서 설정)
+     * OAuth 로그인 사용자 정보 (Passport에서 설정).
+     * optionalAuth 훅 통과 후 미인증 시 null로 설정됨.
      */
-    user?: OAuthAccount;
+    user?: OAuthAccount | null;
   }
 }


### PR DESCRIPTION
## Summary

Closes #31

Implements the auth system: admin login/logout, CSRF token endpoint, OAuth route structure, and auth hooks. Most routes and services were already in `main`; this PR completes the remaining requirements - conditional OAuth strategy/route registration via env vars, and explicit `null` assignment in `optionalAuth`.

## Changes

| File | Change |
|------|--------|
| `src/shared/env.ts` | Make `GOOGLE_CLIENT_ID/SECRET` and `GITHUB_CLIENT_ID/SECRET` optional (default `""`) |
| `src/plugins/passport.ts` | Register Google/GitHub strategies only when credentials are configured |
| `src/routes/auth/auth.route.ts` | Register OAuth routes only when credentials are configured |
| `src/hooks/auth.hook.ts` | `optionalAuth` explicitly sets `request.user = null` when unauthenticated |
| `src/types/fastify.d.ts` | Widen `user` type to `OAuthAccount \| null` to reflect `optionalAuth` behavior |
