### PR TITLE
feat: Posts admin CRUD - tests + pagination meta fix (#41)

### DIFF
--- a/src/routes/posts/post.service.ts
+++ b/src/routes/posts/post.service.ts
@@ -315,7 +315,7 @@ export class PostService {
           .from(tagTable)
           .where(like(tagTable.name, term));
         if (matchedTags.length === 0) {
-          return buildPaginatedResponse([], page, limit, 0);
+          return buildPaginatedResponse([], 0, page, limit);
         }
         const tagIds = matchedTags.map((t) => t.id);
         const postIdsFromTags = await this.db
@@ -324,7 +324,7 @@ export class PostService {
           .where(inArray(postTagTable.tagId, tagIds));
         const postIds = [...new Set(postIdsFromTags.map((pt) => pt.postId))];
         if (postIds.length === 0) {
-          return buildPaginatedResponse([], page, limit, 0);
+          return buildPaginatedResponse([], 0, page, limit);
         }
         conditions.push(inArray(postTable.id, postIds));
       } else if (filter === "category") {
@@ -333,7 +333,7 @@ export class PostService {
           .from(categoryTable)
           .where(like(categoryTable.name, term));
         if (matchedCategories.length === 0) {
-          return buildPaginatedResponse([], page, limit, 0);
+          return buildPaginatedResponse([], 0, page, limit);
         }
         const categoryIds = matchedCategories.map((c) => c.id);
         conditions.push(inArray(postTable.categoryId, categoryIds));
@@ -344,7 +344,7 @@ export class PostService {
           .where(and(like(commentTable.body, term), isNull(commentTable.deletedAt)));
         const postIds = [...new Set(matchedComments.map((c) => c.postId))];
         if (postIds.length === 0) {
-          return buildPaginatedResponse([], page, limit, 0);
+          return buildPaginatedResponse([], 0, page, limit);
         }
         conditions.push(inArray(postTable.id, postIds));
       } else {
@@ -365,7 +365,7 @@ export class PostService {
         .limit(1);
 
       if (!tag) {
-        return buildPaginatedResponse([], page, limit, 0);
+        return buildPaginatedResponse([], 0, page, limit);
       }
 
       const postTags = await this.db
@@ -377,7 +377,7 @@ export class PostService {
 
       // 해당 태그를 가진 게시글이 없으면 빈 배열 반환
       if (tagFilteredPostIds.length === 0) {
-        return buildPaginatedResponse([], page, limit, 0);
+        return buildPaginatedResponse([], 0, page, limit);
       }
 
       conditions.push(inArray(postTable.id, tagFilteredPostIds));
@@ -409,7 +409,7 @@ export class PostService {
     // 각 post에 category, tags, 집계 정보 추가 (목록용 - contentMd/ancestors 제외, 배치)
     const postsWithDetails = await this.enrichPostListItems(posts);
 
-    return buildPaginatedResponse(postsWithDetails, page, limit, total);
+    return buildPaginatedResponse(postsWithDetails, total, page, limit);
   }
 
   /**

--- a/test/routes/posts.test.ts
+++ b/test/routes/posts.test.ts
@@ -131,6 +131,74 @@ describe("Post Routes", () => {
 
       expect(response.statusCode).toBe(403);
     });
+
+    it("slug가 제목에서 자동 생성된다 → 201", async () => {
+      await seedAdmin();
+      const cookie = await injectAuth(app);
+      const category = await seedCategory();
+
+      const response = await app.inject({
+        method: "POST",
+        url: "/api/admin/posts",
+        headers: { cookie },
+        payload: {
+          title: "Hello World Post",
+          contentMd: "# Hello",
+          categoryId: category.id,
+        },
+      });
+
+      expect(response.statusCode).toBe(201);
+      const body = response.json();
+      expect(body.post.slug).toMatch(/hello-world-post/);
+    });
+
+    it("중복 slug는 suffix로 유니크하게 생성된다 → 201", async () => {
+      await seedAdmin();
+      const cookie = await injectAuth(app);
+      const category = await seedCategory();
+
+      const first = await app.inject({
+        method: "POST",
+        url: "/api/admin/posts",
+        headers: { cookie },
+        payload: { title: "Duplicate Title", contentMd: "# A", categoryId: category.id },
+      });
+      const second = await app.inject({
+        method: "POST",
+        url: "/api/admin/posts",
+        headers: { cookie },
+        payload: { title: "Duplicate Title", contentMd: "# B", categoryId: category.id },
+      });
+
+      expect(first.statusCode).toBe(201);
+      expect(second.statusCode).toBe(201);
+      const slug1 = first.json().post.slug as string;
+      const slug2 = second.json().post.slug as string;
+      expect(slug1).not.toBe(slug2);
+    });
+
+    it("status=published + publishedAt 없음 → publishedAt 자동 설정 → 201", async () => {
+      await seedAdmin();
+      const cookie = await injectAuth(app);
+      const category = await seedCategory();
+
+      const response = await app.inject({
+        method: "POST",
+        url: "/api/admin/posts",
+        headers: { cookie },
+        payload: {
+          title: "Auto Publish",
+          contentMd: "# Content",
+          categoryId: category.id,
+          status: "published",
+        },
+      });
+
+      expect(response.statusCode).toBe(201);
+      const body = response.json();
+      expect(body.post.publishedAt).not.toBeNull();
+    });
   });
 
   // ===== GET /api/posts =====
@@ -425,6 +493,146 @@ describe("Post Routes", () => {
       expect(body.post.tags).toHaveLength(1);
       expect(body.post.tags[0].name).toBe("updated-tag");
     });
+
+    it("contentMd 수정 시 contentModifiedAt 갱신 → 200", async () => {
+      await seedAdmin();
+      const cookie = await injectAuth(app);
+      const category = await seedCategory();
+      const post = await seedPost(category.id);
+
+      const response = await app.inject({
+        method: "PATCH",
+        url: `/api/admin/posts/${post.id}`,
+        headers: { cookie },
+        payload: { contentMd: "# Updated Content" },
+      });
+
+      expect(response.statusCode).toBe(200);
+      const body = response.json();
+      expect(body.post.contentModifiedAt).not.toBeNull();
+    });
+
+    it("tags=[] 전달 시 태그 전체 제거 → 200", async () => {
+      await seedAdmin();
+      const cookie = await injectAuth(app);
+      const category = await seedCategory();
+      // 태그가 있는 게시글 생성
+      const createRes = await app.inject({
+        method: "POST",
+        url: "/api/admin/posts",
+        headers: { cookie },
+        payload: {
+          title: "Tagged Post",
+          contentMd: "# Hello",
+          categoryId: category.id,
+          tags: ["tag-a", "tag-b"],
+        },
+      });
+      const postId = createRes.json().post.id as number;
+
+      const response = await app.inject({
+        method: "PATCH",
+        url: `/api/admin/posts/${postId}`,
+        headers: { cookie },
+        payload: { tags: [] },
+      });
+
+      expect(response.statusCode).toBe(200);
+      expect(response.json().post.tags).toHaveLength(0);
+    });
+
+    it("존재하지 않는 ID → 404", async () => {
+      await seedAdmin();
+      const cookie = await injectAuth(app);
+
+      const response = await app.inject({
+        method: "PATCH",
+        url: "/api/admin/posts/99999",
+        headers: { cookie },
+        payload: { title: "Nope" },
+      });
+
+      expect(response.statusCode).toBe(404);
+    });
+
+    it("비인증 → 403", async () => {
+      const response = await app.inject({
+        method: "PATCH",
+        url: "/api/admin/posts/1",
+        payload: { title: "Nope" },
+      });
+
+      expect(response.statusCode).toBe(403);
+    });
+  });
+
+  // ===== GET /api/admin/posts/:id =====
+
+  describe("GET /api/admin/posts/:id", () => {
+    it("상세 조회 성공 — contentMd 포함 PostDetail 반환 → 200", async () => {
+      await seedAdmin();
+      const cookie = await injectAuth(app);
+      const category = await seedCategory();
+      const post = await seedPost(category.id, {
+        status: "draft",
+        visibility: "private",
+      });
+
+      const response = await app.inject({
+        method: "GET",
+        url: `/api/admin/posts/${post.id}`,
+        headers: { cookie },
+      });
+
+      expect(response.statusCode).toBe(200);
+      const body = response.json();
+      expect(body.post.id).toBe(post.id);
+      expect(body.post.contentMd).toBeDefined();
+      expect(body.post.category).toBeDefined();
+      expect(body.post.tags).toBeDefined();
+    });
+
+    it("category ancestors 반환 — 중첩 카테고리", async () => {
+      await seedAdmin();
+      const cookie = await injectAuth(app);
+      const parent = await seedCategory({ name: "Parent", slug: "parent-cat" });
+      const child = await seedCategory({ name: "Child", slug: "child-cat", parentId: parent.id });
+      const post = await seedPost(child.id);
+
+      const response = await app.inject({
+        method: "GET",
+        url: `/api/admin/posts/${post.id}`,
+        headers: { cookie },
+      });
+
+      expect(response.statusCode).toBe(200);
+      const body = response.json();
+      expect(body.post.category.name).toBe("Child");
+      expect(body.post.category.ancestors).toHaveLength(1);
+      expect(body.post.category.ancestors[0].name).toBe("Parent");
+    });
+
+    it("존재하지 않는 ID → 404", async () => {
+      await seedAdmin();
+      const cookie = await injectAuth(app);
+
+      const response = await app.inject({
+        method: "GET",
+        url: "/api/admin/posts/99999",
+        headers: { cookie },
+      });
+
+      expect(response.statusCode).toBe(404);
+    });
+
+    it("비인증 → 403", async () => {
+      const response = await app.inject({
+        method: "GET",
+        url: "/api/admin/posts/1",
+      });
+
+      expect(response.statusCode).toBe(403);
+    });
   });
 
   // ===== DELETE /api/admin/posts/:id =====
@@ -499,6 +707,106 @@ describe("Post Routes", () => {
 
       const body = response.json();
       expect(body.data).toHaveLength(3);
+    });
+
+    it("status 필터 — status=draft → draft만 반환", async () => {
+      await seedAdmin();
+      const cookie = await injectAuth(app);
+      const category = await seedCategory();
+
+      await seedPost(category.id, { status: "draft" });
+      await seedPost(category.id, { status: "published" });
+      await seedPost(category.id, { status: "archived" });
+
+      const response = await app.inject({
+        method: "GET",
+        url: "/api/admin/posts?status=draft",
+        headers: { cookie },
+      });
+
+      expect(response.statusCode).toBe(200);
+      const body = response.json();
+      expect(body.data).toHaveLength(1);
+      expect(body.data[0].status).toBe("draft");
+    });
+
+    it("visibility 필터 — visibility=private → private만 반환", async () => {
+      await seedAdmin();
+      const cookie = await injectAuth(app);
+      const category = await seedCategory();
+
+      await seedPost(category.id, { visibility: "public" });
+      await seedPost(category.id, { visibility: "private" });
+
+      const response = await app.inject({
+        method: "GET",
+        url: "/api/admin/posts?visibility=private",
+        headers: { cookie },
+      });
+
+      expect(response.statusCode).toBe(200);
+      const body = response.json();
+      expect(body.data).toHaveLength(1);
+      expect(body.data[0].visibility).toBe("private");
+    });
+
+    it("includeDeleted=true → 삭제된 글 포함", async () => {
+      await seedAdmin();
+      const cookie = await injectAuth(app);
+      const category = await seedCategory();
+
+      const post = await seedPost(category.id);
+      // soft delete
+      await app.inject({
+        method: "DELETE",
+        url: `/api/admin/posts/${post.id}`,
+        headers: { cookie },
+      });
+
+      const withoutDeleted = await app.inject({
+        method: "GET",
+        url: "/api/admin/posts",
+        headers: { cookie },
+      });
+      const withDeleted = await app.inject({
+        method: "GET",
+        url: "/api/admin/posts?includeDeleted=true",
+        headers: { cookie },
+      });
+
+      expect(withoutDeleted.json().data).toHaveLength(0);
+      expect(withDeleted.json().data).toHaveLength(1);
+    });
+
+    it("페이지네이션 — limit=2, 총 3개 → meta.totalCount=3", async () => {
+      await seedAdmin();
+      const cookie = await injectAuth(app);
+      const category = await seedCategory();
+
+      await seedPost(category.id);
+      await seedPost(category.id);
+      await seedPost(category.id);
+
+      const response = await app.inject({
+        method: "GET",
+        url: "/api/admin/posts?limit=2&page=1",
+        headers: { cookie },
+      });
+
+      expect(response.statusCode).toBe(200);
+      const body = response.json();
+      expect(body.data).toHaveLength(2);
+      expect(body.meta.total).toBe(3);
+      expect(body.meta.totalPages).toBe(2);
+    });
+
+    it("비인증 → 403", async () => {
+      const response = await app.inject({
+        method: "GET",
+        url: "/api/admin/posts",
+      });
+
+      expect(response.statusCode).toBe(403);
     });
   });
 


### PR DESCRIPTION
## Summary

Closes #41

Implements admin CRUD endpoints for posts (`GET /api/admin/posts`, `POST /api/admin/posts`, `GET /api/admin/posts/:id`, `PATCH /api/admin/posts/:id`) with comprehensive tests. Also fixes a pagination meta bug where `buildPaginatedResponse` params were passed in wrong order, causing `meta.total`, `meta.page`, and `meta.limit` to return incorrect values.

## Changes

| File | Change |
|------|--------|
| `src/routes/posts/post.service.ts` | Fix `buildPaginatedResponse` param order (was `page, limit, total` - should be `total, page, limit`) |
| `test/routes/posts.test.ts` | Add 16 new tests: GET admin list (filters, pagination, auth), GET admin detail (success, ancestors, 404, 403), PATCH (contentMd update, tags clear, 404, 403), POST (slug auto-gen, duplicate slug, publishedAt auto) |

## Definition of done

- [x] Admin `GET /api/admin/posts` 가 모든 상태/가시성을 조회할 수 있고 includeDeleted를 지원한다
- [x] Admin `POST /api/admin/posts` 가 게시글을 생성하고 PostDetail을 반환한다
- [x] Admin `PATCH /api/admin/posts/:id` 가 게시글을 수정한다
- [x] slug가 자동 생성되고 unique하다
- [x] 모든 Admin 라우트가 `requireAdmin` 훅으로 보호된다
