### PR TITLE
fix: align category tree and mysql row typings

### DIFF
--- a/scripts/db-migration-status.ts
+++ b/scripts/db-migration-status.ts
@@ -1,9 +1,14 @@
 import fs from "node:fs";
 import path from "node:path";
 import mysql from "mysql2/promise";
+import type { RowDataPacket } from "mysql2/promise";
 import { loadEnv, requireDbEnv } from "./db-env";
 
-type MigrationSummaryRow = {
+type TableExistsRow = RowDataPacket & {
+  exists: number;
+};
+
+type MigrationSummaryRow = RowDataPacket & {
   appliedCount: number;
   lastAppliedAt: string | number | null;
 };
@@ -18,7 +23,7 @@ function getLocalMigrationCount(): number {
 }
 
 async function getAppliedMigrationSummary(conn: mysql.Connection) {
-  const [tableRows] = await conn.query<Array<{ exists: number }>>(
+  const [tableRows] = await conn.query<TableExistsRow[]>(
     `
       SELECT COUNT(*) AS exists
       FROM information_schema.tables

--- a/src/routes/categories/category.schema.ts
+++ b/src/routes/categories/category.schema.ts
@@ -1,4 +1,5 @@
 import { z } from "zod";
+import type { CategoryTreeItem } from "./category.service";
 
 /**
  * Path Parameter Schemas
@@ -44,15 +45,23 @@ export const CategoryUpdateBodySchema = z.object({
   isVisible: z.boolean().optional().describe("카테고리 공개 여부"),
 });
 
+const CategoryTreeItemSchema = z
+  .object({
+    id: z.number().int().positive().describe("카테고리 ID"),
+    parentId: z.number().int().positive().nullable().describe("새 부모 카테고리 ID"),
+    sortOrder: z.number().int().min(0).describe("새 정렬 순서"),
+  })
+  .transform(
+    ({ id, parentId, sortOrder }): CategoryTreeItem => ({
+      id,
+      parentId,
+      sortOrder,
+    }),
+  );
+
 export const CategoryTreeUpdateBodySchema = z.object({
   changes: z
-    .array(
-      z.object({
-        id: z.number().int().positive().describe("카테고리 ID"),
-        parentId: z.number().int().positive().nullable().describe("새 부모 카테고리 ID"),
-        sortOrder: z.number().int().min(0).describe("새 정렬 순서"),
-      }),
-    )
+    .array(CategoryTreeItemSchema)
     .min(1, "At least one change is required")
     .max(200, "Too many changes in a single request")
     .describe("변경할 카테고리 목록 (최대 200개)"),

--- a/src/routes/posts/post.service.ts
+++ b/src/routes/posts/post.service.ts
@@ -13,7 +13,7 @@ import {
   or,
 } from "drizzle-orm";
 import { MySql2Database } from "drizzle-orm/mysql2";
-import type { PoolConnection } from "mysql2/promise";
+import type { PoolConnection, RowDataPacket } from "mysql2/promise";
 import { connection } from "@src/db/client";
 import { categoryTable } from "@src/db/schema/categories";
 import { commentTable } from "@src/db/schema/comments";
@@ -34,6 +34,7 @@ const MAX_PINNED_POSTS = 5;
 const PINNED_POST_LIMIT_ERROR =
   "Pinned post limit exceeded. Maximum 5 pinned posts allowed.";
 const PINNED_POST_LIMIT_LOCK_NAME = "post_pinned_limit";
+type NamedLockRow = RowDataPacket & { acquired: number | null };
 
 /**
  * 게시글 생성 입력 데이터
@@ -1170,9 +1171,10 @@ export class PostService {
     const lockConnection = await connection.getConnection();
 
     try {
-      const [lockRows] = await lockConnection.query<
-        Array<{ acquired: number | null }>
-      >("SELECT GET_LOCK(?, 10) AS acquired", [PINNED_POST_LIMIT_LOCK_NAME]);
+      const [lockRows] = await lockConnection.query<NamedLockRow[]>(
+        "SELECT GET_LOCK(?, 10) AS acquired",
+        [PINNED_POST_LIMIT_LOCK_NAME],
+      );
       const acquired = Number(lockRows[0]?.acquired ?? 0);
 
       if (acquired !== 1) {


### PR DESCRIPTION
## 요약
카테고리 트리 변경 요청 스키마와 서비스 타입 간의 정합성을 맞추고, `mysql2` 쿼리 결과 타입을 `RowDataPacket` 기반으로 수정했습니다.

## 원인
- 카테고리 트리 변경 요청의 `changes` 항목이 스키마 내부에서 익명 객체 타입으로 선언되어, 서비스가 기대하는 `CategoryTreeItem` 계약과 분리되어 있었습니다.
- `mysql2/promise`의 `query<T>` 결과를 일반 객체 배열로 지정하고 있어, 실제 드라이버가 반환하는 row packet 타입과 맞지 않는 타입 선언이 남아 있었습니다.

## 분석
- `src/routes/categories/category.schema.ts`에서는 입력값 검증은 가능했지만, 검증 이후 타입이 서비스 레이어의 `CategoryTreeItem`으로 명시적으로 수렴되지 않아 계층 간 타입 드리프트가 발생할 수 있었습니다.
- `src/routes/posts/post.service.ts`의 `GET_LOCK()` 결과와 `scripts/db-migration-status.ts`의 마이그레이션 상태 조회 결과는 모두 MySQL row packet 형태로 반환되는데, 기존 선언은 그 제약을 반영하지 않아 타입 검사 시 불안정했습니다.

## 해결
- `CategoryTreeItemSchema`를 분리하고 `.transform()`으로 `CategoryTreeItem` 타입으로 매핑해 요청 스키마와 서비스 계약을 일치시켰습니다.
- `NamedLockRow`, `TableExistsRow`, `MigrationSummaryRow`를 `RowDataPacket` 확장 타입으로 정의하고 각 `query` 제네릭에 적용했습니다.

## 결과
- 카테고리 트리 변경 요청이 검증 이후에도 서비스가 기대하는 정확한 타입으로 유지됩니다.
- pinned post named lock 조회와 DB migration status 조회에서 MySQL row 결과 타입이 드라이버 계약에 맞게 정리되었습니다.
- 타입 검사 기준으로 관련 타입 오류가 해소되었습니다.

## 검증
- `pnpm compile:types` ✅
- `pnpm test` ❌
  - Vitest 시작 단계에서 `@rollup/rollup-linux-arm64-gnu` optional dependency 누락으로 실행되지 않았습니다.
