### PR TITLE
refactor: rename admin email to username (#78)

### DIFF
--- a/drizzle/0008_admin_username.sql
+++ b/drizzle/0008_admin_username.sql
@@ -1,4 +1,10 @@
 ALTER TABLE `admin_tb`
   DROP INDEX `admin_tb_email_unique`,
-  CHANGE COLUMN `email` `username` varchar(100) CHARACTER SET utf8mb4 COLLATE utf8mb4_bin NOT NULL,
+  CHANGE COLUMN `email` `username` varchar(100) CHARACTER SET utf8mb4 COLLATE utf8mb4_bin NOT NULL;
+
+UPDATE `admin_tb`
+SET `username` = LOWER(`username`)
+WHERE `username` LIKE '%@%';
+
+ALTER TABLE `admin_tb`
   ADD CONSTRAINT `admin_tb_username_unique` UNIQUE(`username`);

--- a/drizzle/0008_admin_username.sql
+++ b/drizzle/0008_admin_username.sql
@@ -1,0 +1,4 @@
+ALTER TABLE `admin_tb`
+  DROP INDEX `admin_tb_email_unique`,
+  CHANGE COLUMN `email` `username` varchar(100) CHARACTER SET utf8mb4 COLLATE utf8mb4_bin NOT NULL,
+  ADD CONSTRAINT `admin_tb_username_unique` UNIQUE(`username`);

--- a/drizzle/meta/_journal.json
+++ b/drizzle/meta/_journal.json
@@ -57,6 +57,13 @@
       "when": 1774695600000,
       "tag": "0007_comment_reveal_token",
       "breakpoints": true
+    },
+    {
+      "idx": 8,
+      "version": "5",
+      "when": 1775476800000,
+      "tag": "0008_admin_username",
+      "breakpoints": true
     }
   ]
 }

--- a/scripts/README.md
+++ b/scripts/README.md
@@ -26,8 +26,8 @@ $argon2id$v=19$m=65536,t=3,p=1$abc123...$xyz789...
 ### 어드민 계정 생성 (MySQL)
 
 ```sql
-INSERT INTO admin_tb (email, password_hash)
-VALUES ('admin@example.com', '<출력된 해시>');
+INSERT INTO admin_tb (username, password_hash)
+VALUES ('admin.test', '<출력된 해시>');
 ```
 
 ### 비밀번호 초기화 (MySQL)
@@ -35,7 +35,7 @@ VALUES ('admin@example.com', '<출력된 해시>');
 ```sql
 UPDATE admin_tb
 SET password_hash = '<출력된 해시>'
-WHERE email = 'admin@example.com';
+WHERE username = 'admin.test';
 ```
 
 ### 참고

--- a/scripts/hash-password.ts
+++ b/scripts/hash-password.ts
@@ -5,8 +5,8 @@
  *   pnpm tsx scripts/hash-password.ts "my-password"
  *
  * 출력된 해시를 사용하여 DB에 직접 관리자 계정을 생성합니다:
- *   INSERT INTO admin_tb (email, password_hash)
- *   VALUES ('admin@example.com', '<출력된 해시>');
+ *   INSERT INTO admin_tb (username, password_hash)
+ *   VALUES ('admin.test', '<출력된 해시>');
  */
 import * as argon2 from "argon2";
 

--- a/src/db/schema/admins.ts
+++ b/src/db/schema/admins.ts
@@ -5,7 +5,7 @@ import { mysqlTable, int, varchar, timestamp } from "drizzle-orm/mysql-core";
  */
 export const adminTable = mysqlTable("admin_tb", {
   id: int("id").primaryKey().autoincrement(),
-  email: varchar("email", { length: 100 }).notNull().unique(),
+  username: varchar("username", { length: 100 }).notNull().unique(),
   passwordHash: varchar("password_hash", { length: 255 }).notNull(),
   createdAt: timestamp("created_at").defaultNow().notNull(),
   updatedAt: timestamp("updated_at").defaultNow().onUpdateNow().notNull(),

--- a/src/routes/auth/admin.service.ts
+++ b/src/routes/auth/admin.service.ts
@@ -1,4 +1,4 @@
-import { eq } from "drizzle-orm";
+import { eq, sql } from "drizzle-orm";
 import { MySql2Database } from "drizzle-orm/mysql2";
 import { Admin, adminTable } from "@src/db/schema/admins";
 import * as schema from "@src/db/schema/index";
@@ -9,6 +9,8 @@ import { verifyPassword } from "@src/shared/password";
  * Admin 계정 반환 타입 (password_hash 제외)
  */
 export type AdminResponse = Omit<Admin, "passwordHash">;
+
+const LEGACY_EMAIL_REGEX = /^[^\s@]+@[^\s@]+\.[^\s@]+$/;
 
 /**
  * Admin 서비스 (관리자 계정 관리 및 인증)
@@ -26,11 +28,16 @@ export class AdminService {
     username: string,
     password: string,
   ): Promise<AdminResponse> {
-    // 사용자명으로 관리자 조회
+    const identifier = username;
+    const isLegacyEmail = LEGACY_EMAIL_REGEX.test(identifier);
     const [admin] = await this.db
       .select()
       .from(adminTable)
-      .where(eq(adminTable.username, username))
+      .where(
+        isLegacyEmail
+          ? sql`lower(${adminTable.username}) = lower(${identifier})`
+          : eq(adminTable.username, identifier),
+      )
       .limit(1);
 
     if (!admin) {

--- a/src/routes/auth/admin.service.ts
+++ b/src/routes/auth/admin.service.ts
@@ -1,4 +1,4 @@
-import { eq, sql } from "drizzle-orm";
+import { eq } from "drizzle-orm";
 import { MySql2Database } from "drizzle-orm/mysql2";
 import { Admin, adminTable } from "@src/db/schema/admins";
 import * as schema from "@src/db/schema/index";
@@ -29,15 +29,13 @@ export class AdminService {
     password: string,
   ): Promise<AdminResponse> {
     const identifier = username;
-    const isLegacyEmail = LEGACY_EMAIL_REGEX.test(identifier);
+    const normalizedIdentifier = LEGACY_EMAIL_REGEX.test(identifier)
+      ? identifier.toLowerCase()
+      : identifier;
     const [admin] = await this.db
       .select()
       .from(adminTable)
-      .where(
-        isLegacyEmail
-          ? sql`lower(${adminTable.username}) = lower(${identifier})`
-          : eq(adminTable.username, identifier),
-      )
+      .where(eq(adminTable.username, normalizedIdentifier))
       .limit(1);
 
     if (!admin) {

--- a/src/routes/auth/admin.service.ts
+++ b/src/routes/auth/admin.service.ts
@@ -17,30 +17,30 @@ export class AdminService {
   constructor(private readonly db: MySql2Database<typeof schema>) {}
 
   /**
-   * 이메일/비밀번호 검증
-   * @param email 이메일 주소
+   * 사용자명/비밀번호 검증
+   * @param username 관리자 사용자명
    * @param password 평문 비밀번호
    * @returns 인증된 관리자 정보 (password_hash 제외)
    */
   async verifyCredentials(
-    email: string,
+    username: string,
     password: string,
   ): Promise<AdminResponse> {
-    // 이메일로 관리자 조회
+    // 사용자명으로 관리자 조회
     const [admin] = await this.db
       .select()
       .from(adminTable)
-      .where(eq(adminTable.email, email))
+      .where(eq(adminTable.username, username))
       .limit(1);
 
     if (!admin) {
-      throw HttpError.unauthorized("Invalid email or password.");
+      throw HttpError.unauthorized("Invalid username or password.");
     }
 
     // 비밀번호 검증
     const isValid = await verifyPassword(admin.passwordHash, password);
     if (!isValid) {
-      throw HttpError.unauthorized("Invalid email or password.");
+      throw HttpError.unauthorized("Invalid username or password.");
     }
 
     // last_login_at 업데이트

--- a/src/routes/auth/auth.route.ts
+++ b/src/routes/auth/auth.route.ts
@@ -8,12 +8,17 @@ import { ErrorResponseSchema } from "@src/schemas/common";
 import { env } from "@src/shared/env";
 
 const ADMIN_USERNAME_REGEX = /^[\p{L}\p{N}_.-]+$/u;
+const LEGACY_EMAIL_REGEX = /^[^\s@]+@[^\s@]+\.[^\s@]+$/;
 
 function toAdminResponse(admin: AdminResponse) {
+  const legacyEmail = LEGACY_EMAIL_REGEX.test(admin.username)
+    ? admin.username
+    : null;
+
   return {
     id: admin.id,
     username: admin.username,
-    email: admin.username,
+    email: legacyEmail,
     createdAt: admin.createdAt,
     updatedAt: admin.updatedAt,
     lastLoginAt: admin.lastLoginAt,
@@ -21,23 +26,50 @@ function toAdminResponse(admin: AdminResponse) {
 }
 
 // Zod 스키마 정의
-const AdminLoginSchema = z.object({
-  email: z
-    .string()
-    .min(4, "사용자명은 최소 4자 이상이어야 합니다")
-    .max(100, "관리자 식별자는 최대 100자까지 가능합니다")
-    .refine(
-      (value) =>
-        z.string().email().safeParse(value).success ||
-        ADMIN_USERNAME_REGEX.test(value),
-      "관리자 식별자는 이메일 또는 사용자명 형식이어야 합니다",
-    )
-    .describe("관리자 사용자명 또는 기존 이메일"),
-  password: z
-    .string()
-    .min(8, "비밀번호는 최소 8자 이상이어야 합니다")
-    .describe("관리자 비밀번호 (최소 8자)"),
-});
+const AdminLoginSchema = z
+  .object({
+    username: z
+      .string()
+      .min(4, "사용자명은 최소 4자 이상이어야 합니다")
+      .max(100, "관리자 식별자는 최대 100자까지 가능합니다")
+      .refine(
+        (value) =>
+          z.string().email().safeParse(value).success ||
+          ADMIN_USERNAME_REGEX.test(value),
+        "관리자 식별자는 이메일 또는 사용자명 형식이어야 합니다",
+      )
+      .optional()
+      .describe("관리자 사용자명"),
+    email: z
+      .string()
+      .min(4, "관리자 식별자는 최소 4자 이상이어야 합니다")
+      .max(100, "관리자 식별자는 최대 100자까지 가능합니다")
+      .optional()
+      .describe("기존 이메일 식별자 호환 필드"),
+    password: z
+      .string()
+      .min(8, "비밀번호는 최소 8자 이상이어야 합니다")
+      .describe("관리자 비밀번호 (최소 8자)"),
+  })
+  .superRefine((value, ctx) => {
+    if (!value.username && !value.email) {
+      ctx.addIssue({
+        code: z.ZodIssueCode.custom,
+        path: ["username"],
+        message: "username 또는 email 중 하나는 필요합니다",
+      });
+
+      return;
+    }
+
+    if (value.email && value.username && value.email !== value.username) {
+      ctx.addIssue({
+        code: z.ZodIssueCode.custom,
+        path: ["email"],
+        message: "email 필드는 username과 동일한 legacy alias만 허용합니다",
+      });
+    }
+  });
 
 /**
  * Auth 라우트 플러그인
@@ -137,7 +169,7 @@ export function createAuthRoute(
               admin: z.object({
                 id: z.number(),
                 username: z.string(),
-                email: z.string(),
+                email: z.string().nullable(),
                 createdAt: z.date(),
                 updatedAt: z.date(),
                 lastLoginAt: z.date().nullable(),
@@ -149,10 +181,18 @@ export function createAuthRoute(
         },
       },
       async (request, reply) => {
-        const { email, password } = request.body;
+        const { username, email, password } = request.body;
+        const identifier = username ?? email;
 
-        // 요청 필드명은 유지하되 내부 source of truth는 username이다.
-        const admin = await adminService.verifyCredentials(email, password);
+        if (!identifier) {
+          throw HttpError.badRequest("username is required.");
+        }
+
+        // username을 우선으로 사용하고 email은 전환 기간 alias로만 허용한다.
+        const admin = await adminService.verifyCredentials(
+          identifier,
+          password,
+        );
 
         // 세션에 adminId 저장
         request.session.set("adminId", admin.id);
@@ -204,7 +244,7 @@ export function createAuthRoute(
                 type: z.literal("admin"),
                 id: z.number(),
                 username: z.string(),
-                email: z.string(),
+                email: z.string().nullable(),
                 createdAt: z.date(),
                 updatedAt: z.date(),
                 lastLoginAt: z.date().nullable(),

--- a/src/routes/auth/auth.route.ts
+++ b/src/routes/auth/auth.route.ts
@@ -8,15 +8,12 @@ import { ErrorResponseSchema } from "@src/schemas/common";
 import { env } from "@src/shared/env";
 
 const ADMIN_USERNAME_REGEX = /^[\p{L}\p{N}_.-]+$/u;
-const LEGACY_EMAIL_REGEX = /^[^\s@]+@[^\s@]+\.[^\s@]+$/;
 
 function toAdminResponse(admin: AdminResponse) {
-  const isLegacyEmail = LEGACY_EMAIL_REGEX.test(admin.username);
-
   return {
     id: admin.id,
     username: admin.username,
-    email: isLegacyEmail ? admin.username : null,
+    email: admin.username,
     createdAt: admin.createdAt,
     updatedAt: admin.updatedAt,
     lastLoginAt: admin.lastLoginAt,
@@ -140,7 +137,7 @@ export function createAuthRoute(
               admin: z.object({
                 id: z.number(),
                 username: z.string(),
-                email: z.string().nullable(),
+                email: z.string(),
                 createdAt: z.date(),
                 updatedAt: z.date(),
                 lastLoginAt: z.date().nullable(),
@@ -207,7 +204,7 @@ export function createAuthRoute(
                 type: z.literal("admin"),
                 id: z.number(),
                 username: z.string(),
-                email: z.string().nullable(),
+                email: z.string(),
                 createdAt: z.date(),
                 updatedAt: z.date(),
                 lastLoginAt: z.date().nullable(),

--- a/src/routes/auth/auth.route.ts
+++ b/src/routes/auth/auth.route.ts
@@ -7,17 +7,21 @@ import { HttpError } from "@src/errors/http-error";
 import { ErrorResponseSchema } from "@src/schemas/common";
 import { env } from "@src/shared/env";
 
+const ADMIN_USERNAME_REGEX = /^[\p{L}\p{N}_.-]+$/u;
+
 // Zod 스키마 정의
 const AdminLoginSchema = z.object({
   email: z
     .string()
     .min(4, "사용자명은 최소 4자 이상이어야 합니다")
-    .max(20, "사용자명은 최대 20자까지 가능합니다")
-    .regex(
-      /^[\p{L}\p{N}_.-]+$/u,
-      "사용자명은 문자, 숫자, _, ., - 만 사용할 수 있습니다",
+    .max(100, "관리자 식별자는 최대 100자까지 가능합니다")
+    .refine(
+      (value) =>
+        z.string().email().safeParse(value).success ||
+        ADMIN_USERNAME_REGEX.test(value),
+      "관리자 식별자는 이메일 또는 사용자명 형식이어야 합니다",
     )
-    .describe("관리자 사용자명"),
+    .describe("관리자 사용자명 또는 기존 이메일"),
   password: z
     .string()
     .min(8, "비밀번호는 최소 8자 이상이어야 합니다")
@@ -114,7 +118,7 @@ export function createAuthRoute(
           tags: ["auth"],
           summary: "Admin login",
           description:
-            "관리자 사용자명/비밀번호로 로그인합니다.\n\n" +
+            "관리자 사용자명/비밀번호로 로그인합니다. 기존 배포 환경의 이메일 식별자도 전환 기간 동안 허용합니다.\n\n" +
             "**Rate limit**: 5회/분",
           body: AdminLoginSchema,
           response: {

--- a/src/routes/auth/auth.route.ts
+++ b/src/routes/auth/auth.route.ts
@@ -4,13 +4,24 @@ import { ZodTypeProvider } from "fastify-type-provider-zod";
 import { z } from "zod";
 import { AdminService } from "./admin.service";
 import { HttpError } from "@src/errors/http-error";
-import { env } from "@src/shared/env";
 import { ErrorResponseSchema } from "@src/schemas/common";
+import { env } from "@src/shared/env";
 
 // Zod 스키마 정의
 const AdminLoginSchema = z.object({
-  email: z.string().email("유효한 이메일 주소를 입력하세요").describe("관리자 이메일"),
-  password: z.string().min(8, "비밀번호는 최소 8자 이상이어야 합니다").describe("관리자 비밀번호 (최소 8자)"),
+  email: z
+    .string()
+    .min(4, "사용자명은 최소 4자 이상이어야 합니다")
+    .max(20, "사용자명은 최대 20자까지 가능합니다")
+    .regex(
+      /^[\p{L}\p{N}_.-]+$/u,
+      "사용자명은 문자, 숫자, _, ., - 만 사용할 수 있습니다",
+    )
+    .describe("관리자 사용자명"),
+  password: z
+    .string()
+    .min(8, "비밀번호는 최소 8자 이상이어야 합니다")
+    .describe("관리자 비밀번호 (최소 8자)"),
 });
 
 /**
@@ -103,7 +114,7 @@ export function createAuthRoute(
           tags: ["auth"],
           summary: "Admin login",
           description:
-            "관리자 이메일/비밀번호로 로그인합니다.\n\n" +
+            "관리자 사용자명/비밀번호로 로그인합니다.\n\n" +
             "**Rate limit**: 5회/분",
           body: AdminLoginSchema,
           response: {
@@ -124,13 +135,18 @@ export function createAuthRoute(
       async (request, reply) => {
         const { email, password } = request.body;
 
-        // 인증 검증
+        // 요청 필드명은 유지하되 내부 source of truth는 username이다.
         const admin = await adminService.verifyCredentials(email, password);
 
         // 세션에 adminId 저장
         request.session.set("adminId", admin.id);
 
-        return reply.status(200).send({ admin });
+        return reply.status(200).send({
+          admin: {
+            ...admin,
+            email: admin.username,
+          },
+        });
       },
     );
 
@@ -202,6 +218,7 @@ export function createAuthRoute(
           return reply.status(200).send({
             type: "admin" as const,
             ...admin,
+            email: admin.username,
           });
         }
 

--- a/src/routes/auth/auth.route.ts
+++ b/src/routes/auth/auth.route.ts
@@ -42,8 +42,7 @@ const AdminLoginSchema = z
       .describe("관리자 사용자명"),
     email: z
       .string()
-      .min(4, "관리자 식별자는 최소 4자 이상이어야 합니다")
-      .max(100, "관리자 식별자는 최대 100자까지 가능합니다")
+      .email("legacy email alias는 이메일 형식이어야 합니다")
       .optional()
       .describe("기존 이메일 식별자 호환 필드"),
     password: z

--- a/src/routes/auth/auth.route.ts
+++ b/src/routes/auth/auth.route.ts
@@ -2,12 +2,26 @@ import fastifyPassport from "@fastify/passport";
 import { FastifyPluginAsync, FastifyInstance } from "fastify";
 import { ZodTypeProvider } from "fastify-type-provider-zod";
 import { z } from "zod";
-import { AdminService } from "./admin.service";
+import { AdminResponse, AdminService } from "./admin.service";
 import { HttpError } from "@src/errors/http-error";
 import { ErrorResponseSchema } from "@src/schemas/common";
 import { env } from "@src/shared/env";
 
 const ADMIN_USERNAME_REGEX = /^[\p{L}\p{N}_.-]+$/u;
+const LEGACY_EMAIL_REGEX = /^[^\s@]+@[^\s@]+\.[^\s@]+$/;
+
+function toAdminResponse(admin: AdminResponse) {
+  const isLegacyEmail = LEGACY_EMAIL_REGEX.test(admin.username);
+
+  return {
+    id: admin.id,
+    username: admin.username,
+    email: isLegacyEmail ? admin.username : null,
+    createdAt: admin.createdAt,
+    updatedAt: admin.updatedAt,
+    lastLoginAt: admin.lastLoginAt,
+  };
+}
 
 // Zod 스키마 정의
 const AdminLoginSchema = z.object({
@@ -125,7 +139,8 @@ export function createAuthRoute(
             200: z.object({
               admin: z.object({
                 id: z.number(),
-                email: z.string(),
+                username: z.string(),
+                email: z.string().nullable(),
                 createdAt: z.date(),
                 updatedAt: z.date(),
                 lastLoginAt: z.date().nullable(),
@@ -146,10 +161,7 @@ export function createAuthRoute(
         request.session.set("adminId", admin.id);
 
         return reply.status(200).send({
-          admin: {
-            ...admin,
-            email: admin.username,
-          },
+          admin: toAdminResponse(admin),
         });
       },
     );
@@ -194,7 +206,8 @@ export function createAuthRoute(
               z.object({
                 type: z.literal("admin"),
                 id: z.number(),
-                email: z.string(),
+                username: z.string(),
+                email: z.string().nullable(),
                 createdAt: z.date(),
                 updatedAt: z.date(),
                 lastLoginAt: z.date().nullable(),
@@ -221,8 +234,7 @@ export function createAuthRoute(
 
           return reply.status(200).send({
             type: "admin" as const,
-            ...admin,
-            email: admin.username,
+            ...toAdminResponse(admin),
           });
         }
 

--- a/test/helpers/app.ts
+++ b/test/helpers/app.ts
@@ -6,7 +6,7 @@ import { sessionTable } from "@src/db/schema";
 import { env } from "@src/shared/env";
 
 /** 테스트용 Admin 기본 자격증명 */
-export const TEST_ADMIN_EMAIL = "admin@test.pyosh.dev";
+export const TEST_ADMIN_USERNAME = "admin.test";
 export const TEST_ADMIN_PASSWORD = "Test12345!";
 
 /**
@@ -34,7 +34,7 @@ export async function injectAuth(
     method: "POST",
     url: "/api/auth/admin/login",
     payload: {
-      email: TEST_ADMIN_EMAIL,
+      email: TEST_ADMIN_USERNAME,
       password: TEST_ADMIN_PASSWORD,
     },
   });

--- a/test/helpers/app.ts
+++ b/test/helpers/app.ts
@@ -34,7 +34,7 @@ export async function injectAuth(
     method: "POST",
     url: "/api/auth/admin/login",
     payload: {
-      email: TEST_ADMIN_USERNAME,
+      username: TEST_ADMIN_USERNAME,
       password: TEST_ADMIN_PASSWORD,
     },
   });

--- a/test/helpers/seed.ts
+++ b/test/helpers/seed.ts
@@ -1,5 +1,5 @@
 import { eq, sql } from "drizzle-orm";
-import { TEST_ADMIN_EMAIL, TEST_ADMIN_PASSWORD } from "./app";
+import { TEST_ADMIN_PASSWORD, TEST_ADMIN_USERNAME } from "./app";
 import { db } from "@src/db/client";
 import {
   adminTable,
@@ -48,16 +48,18 @@ export async function truncateAll(): Promise<void> {
  * 테스트 Admin 계정 생성
  */
 export async function seedAdmin(overrides?: {
-  email?: string;
+  username?: string;
   password?: string;
-}): Promise<{ id: number; email: string }> {
-  const email = overrides?.email ?? TEST_ADMIN_EMAIL;
+}): Promise<{ id: number; username: string }> {
+  const username = overrides?.username ?? TEST_ADMIN_USERNAME;
   const password = overrides?.password ?? TEST_ADMIN_PASSWORD;
   const passwordHash = await hashPassword(password);
 
-  const [result] = await db.insert(adminTable).values({ email, passwordHash });
+  const [result] = await db
+    .insert(adminTable)
+    .values({ username, passwordHash });
 
-  return { id: Number(result.insertId), email };
+  return { id: Number(result.insertId), username };
 }
 
 /**

--- a/test/routes/auth.test.ts
+++ b/test/routes/auth.test.ts
@@ -77,6 +77,25 @@ describe("Auth Routes", () => {
       expect(response.statusCode).toBe(401);
     });
 
+    it("기존 이메일 식별자도 전환 기간 동안 로그인 가능 → 200", async () => {
+      await truncateAll();
+      await seedAdmin({ username: "admin@test.pyosh.dev" });
+
+      const response = await app.inject({
+        method: "POST",
+        url: "/api/auth/admin/login",
+        payload: {
+          email: "admin@test.pyosh.dev",
+          password: TEST_ADMIN_PASSWORD,
+        },
+      });
+
+      expect(response.statusCode).toBe(200);
+
+      const body = response.json();
+      expect(body.admin.email).toBe("admin@test.pyosh.dev");
+    });
+
     it("DB에 admin이 없을 때 로그인 → 401 + 에러 메시지", async () => {
       await truncateAll();
 

--- a/test/routes/auth.test.ts
+++ b/test/routes/auth.test.ts
@@ -35,7 +35,7 @@ describe("Auth Routes", () => {
         method: "POST",
         url: "/api/auth/admin/login",
         payload: {
-          email: TEST_ADMIN_USERNAME,
+          username: TEST_ADMIN_USERNAME,
           password: TEST_ADMIN_PASSWORD,
         },
       });
@@ -45,7 +45,7 @@ describe("Auth Routes", () => {
       const body = response.json();
       expect(body.admin).toBeDefined();
       expect(body.admin.username).toBe(TEST_ADMIN_USERNAME);
-      expect(body.admin.email).toBe(TEST_ADMIN_USERNAME);
+      expect(body.admin.email).toBeNull();
       expect(body.admin).not.toHaveProperty("passwordHash");
 
       const setCookie = response.headers["set-cookie"];
@@ -57,7 +57,7 @@ describe("Auth Routes", () => {
         method: "POST",
         url: "/api/auth/admin/login",
         payload: {
-          email: TEST_ADMIN_USERNAME,
+          username: TEST_ADMIN_USERNAME,
           password: "WrongPassword1!",
         },
       });
@@ -70,7 +70,7 @@ describe("Auth Routes", () => {
         method: "POST",
         url: "/api/auth/admin/login",
         payload: {
-          email: "missing-user",
+          username: "missing-user",
           password: TEST_ADMIN_PASSWORD,
         },
       });
@@ -79,6 +79,27 @@ describe("Auth Routes", () => {
     });
 
     it("기존 이메일 식별자도 전환 기간 동안 로그인 가능 → 200", async () => {
+      await truncateAll();
+      await seedAdmin({ username: "admin@test.pyosh.dev" });
+
+      const response = await app.inject({
+        method: "POST",
+        url: "/api/auth/admin/login",
+        payload: {
+          username: "admin@test.pyosh.dev",
+          email: "admin@test.pyosh.dev",
+          password: TEST_ADMIN_PASSWORD,
+        },
+      });
+
+      expect(response.statusCode).toBe(200);
+
+      const body = response.json();
+      expect(body.admin.username).toBe("admin@test.pyosh.dev");
+      expect(body.admin.email).toBe("admin@test.pyosh.dev");
+    });
+
+    it("legacy email alias만 보내도 로그인 가능 → 200", async () => {
       await truncateAll();
       await seedAdmin({ username: "admin@test.pyosh.dev" });
 
@@ -106,6 +127,7 @@ describe("Auth Routes", () => {
         method: "POST",
         url: "/api/auth/admin/login",
         payload: {
+          username: "Admin@Test.pyosh.dev",
           email: "Admin@Test.pyosh.dev",
           password: TEST_ADMIN_PASSWORD,
         },
@@ -125,7 +147,7 @@ describe("Auth Routes", () => {
         method: "POST",
         url: "/api/auth/admin/login",
         payload: {
-          email: TEST_ADMIN_USERNAME,
+          username: TEST_ADMIN_USERNAME,
           password: TEST_ADMIN_PASSWORD,
         },
       });
@@ -167,7 +189,7 @@ describe("Auth Routes", () => {
       const body = response.json();
       expect(body.type).toBe("admin");
       expect(body.username).toBe(TEST_ADMIN_USERNAME);
-      expect(body.email).toBe(TEST_ADMIN_USERNAME);
+      expect(body.email).toBeNull();
     });
 
     it("비로그인 → 401", async () => {
@@ -190,7 +212,7 @@ describe("Auth Routes", () => {
         method: "POST",
         url: "/api/auth/admin/login",
         payload: {
-          email: TEST_ADMIN_USERNAME,
+          username: TEST_ADMIN_USERNAME,
           password: TEST_ADMIN_PASSWORD,
         },
       });

--- a/test/routes/auth.test.ts
+++ b/test/routes/auth.test.ts
@@ -3,8 +3,8 @@ import { describe, it, expect, beforeAll, afterAll, beforeEach } from "vitest";
 import {
   createTestApp,
   cleanup,
-  TEST_ADMIN_EMAIL,
   TEST_ADMIN_PASSWORD,
+  TEST_ADMIN_USERNAME,
 } from "@test/helpers/app";
 import { seedAdmin, truncateAll } from "@test/helpers/seed";
 
@@ -35,7 +35,7 @@ describe("Auth Routes", () => {
         method: "POST",
         url: "/api/auth/admin/login",
         payload: {
-          email: TEST_ADMIN_EMAIL,
+          email: TEST_ADMIN_USERNAME,
           password: TEST_ADMIN_PASSWORD,
         },
       });
@@ -44,7 +44,7 @@ describe("Auth Routes", () => {
 
       const body = response.json();
       expect(body.admin).toBeDefined();
-      expect(body.admin.email).toBe(TEST_ADMIN_EMAIL);
+      expect(body.admin.email).toBe(TEST_ADMIN_USERNAME);
       expect(body.admin).not.toHaveProperty("passwordHash");
 
       const setCookie = response.headers["set-cookie"];
@@ -56,7 +56,7 @@ describe("Auth Routes", () => {
         method: "POST",
         url: "/api/auth/admin/login",
         payload: {
-          email: TEST_ADMIN_EMAIL,
+          email: TEST_ADMIN_USERNAME,
           password: "WrongPassword1!",
         },
       });
@@ -64,12 +64,12 @@ describe("Auth Routes", () => {
       expect(response.statusCode).toBe(401);
     });
 
-    it("존재하지 않는 이메일 → 401", async () => {
+    it("존재하지 않는 사용자명 → 401", async () => {
       const response = await app.inject({
         method: "POST",
         url: "/api/auth/admin/login",
         payload: {
-          email: "notexist@test.pyosh.dev",
+          email: "missing-user",
           password: TEST_ADMIN_PASSWORD,
         },
       });
@@ -84,7 +84,7 @@ describe("Auth Routes", () => {
         method: "POST",
         url: "/api/auth/admin/login",
         payload: {
-          email: TEST_ADMIN_EMAIL,
+          email: TEST_ADMIN_USERNAME,
           password: TEST_ADMIN_PASSWORD,
         },
       });
@@ -106,7 +106,7 @@ describe("Auth Routes", () => {
         method: "POST",
         url: "/api/auth/admin/login",
         payload: {
-          email: TEST_ADMIN_EMAIL,
+          email: TEST_ADMIN_USERNAME,
           password: TEST_ADMIN_PASSWORD,
         },
       });
@@ -125,7 +125,7 @@ describe("Auth Routes", () => {
 
       const body = response.json();
       expect(body.type).toBe("admin");
-      expect(body.email).toBe(TEST_ADMIN_EMAIL);
+      expect(body.email).toBe(TEST_ADMIN_USERNAME);
     });
 
     it("비로그인 → 401", async () => {
@@ -148,7 +148,7 @@ describe("Auth Routes", () => {
         method: "POST",
         url: "/api/auth/admin/login",
         payload: {
-          email: TEST_ADMIN_EMAIL,
+          email: TEST_ADMIN_USERNAME,
           password: TEST_ADMIN_PASSWORD,
         },
       });

--- a/test/routes/auth.test.ts
+++ b/test/routes/auth.test.ts
@@ -45,7 +45,7 @@ describe("Auth Routes", () => {
       const body = response.json();
       expect(body.admin).toBeDefined();
       expect(body.admin.username).toBe(TEST_ADMIN_USERNAME);
-      expect(body.admin.email).toBeNull();
+      expect(body.admin.email).toBe(TEST_ADMIN_USERNAME);
       expect(body.admin).not.toHaveProperty("passwordHash");
 
       const setCookie = response.headers["set-cookie"];
@@ -100,13 +100,13 @@ describe("Auth Routes", () => {
 
     it("기존 이메일 식별자는 대소문자 구분 없이 로그인 가능 → 200", async () => {
       await truncateAll();
-      await seedAdmin({ username: "Admin@Test.pyosh.dev" });
+      await seedAdmin({ username: "admin@test.pyosh.dev" });
 
       const response = await app.inject({
         method: "POST",
         url: "/api/auth/admin/login",
         payload: {
-          email: "admin@test.pyosh.dev",
+          email: "Admin@Test.pyosh.dev",
           password: TEST_ADMIN_PASSWORD,
         },
       });
@@ -114,8 +114,8 @@ describe("Auth Routes", () => {
       expect(response.statusCode).toBe(200);
 
       const body = response.json();
-      expect(body.admin.username).toBe("Admin@Test.pyosh.dev");
-      expect(body.admin.email).toBe("Admin@Test.pyosh.dev");
+      expect(body.admin.username).toBe("admin@test.pyosh.dev");
+      expect(body.admin.email).toBe("admin@test.pyosh.dev");
     });
 
     it("DB에 admin이 없을 때 로그인 → 401 + 에러 메시지", async () => {
@@ -167,7 +167,7 @@ describe("Auth Routes", () => {
       const body = response.json();
       expect(body.type).toBe("admin");
       expect(body.username).toBe(TEST_ADMIN_USERNAME);
-      expect(body.email).toBeNull();
+      expect(body.email).toBe(TEST_ADMIN_USERNAME);
     });
 
     it("비로그인 → 401", async () => {

--- a/test/routes/auth.test.ts
+++ b/test/routes/auth.test.ts
@@ -119,6 +119,19 @@ describe("Auth Routes", () => {
       expect(body.admin.email).toBe("admin@test.pyosh.dev");
     });
 
+    it("email alias에 username 값을 보내면 → 400", async () => {
+      const response = await app.inject({
+        method: "POST",
+        url: "/api/auth/admin/login",
+        payload: {
+          email: TEST_ADMIN_USERNAME,
+          password: TEST_ADMIN_PASSWORD,
+        },
+      });
+
+      expect(response.statusCode).toBe(400);
+    });
+
     it("기존 이메일 식별자는 대소문자 구분 없이 로그인 가능 → 200", async () => {
       await truncateAll();
       await seedAdmin({ username: "admin@test.pyosh.dev" });
@@ -169,7 +182,7 @@ describe("Auth Routes", () => {
         method: "POST",
         url: "/api/auth/admin/login",
         payload: {
-          email: TEST_ADMIN_USERNAME,
+          username: TEST_ADMIN_USERNAME,
           password: TEST_ADMIN_PASSWORD,
         },
       });

--- a/test/routes/auth.test.ts
+++ b/test/routes/auth.test.ts
@@ -44,7 +44,8 @@ describe("Auth Routes", () => {
 
       const body = response.json();
       expect(body.admin).toBeDefined();
-      expect(body.admin.email).toBe(TEST_ADMIN_USERNAME);
+      expect(body.admin.username).toBe(TEST_ADMIN_USERNAME);
+      expect(body.admin.email).toBeNull();
       expect(body.admin).not.toHaveProperty("passwordHash");
 
       const setCookie = response.headers["set-cookie"];
@@ -93,7 +94,28 @@ describe("Auth Routes", () => {
       expect(response.statusCode).toBe(200);
 
       const body = response.json();
+      expect(body.admin.username).toBe("admin@test.pyosh.dev");
       expect(body.admin.email).toBe("admin@test.pyosh.dev");
+    });
+
+    it("기존 이메일 식별자는 대소문자 구분 없이 로그인 가능 → 200", async () => {
+      await truncateAll();
+      await seedAdmin({ username: "Admin@Test.pyosh.dev" });
+
+      const response = await app.inject({
+        method: "POST",
+        url: "/api/auth/admin/login",
+        payload: {
+          email: "admin@test.pyosh.dev",
+          password: TEST_ADMIN_PASSWORD,
+        },
+      });
+
+      expect(response.statusCode).toBe(200);
+
+      const body = response.json();
+      expect(body.admin.username).toBe("Admin@Test.pyosh.dev");
+      expect(body.admin.email).toBe("Admin@Test.pyosh.dev");
     });
 
     it("DB에 admin이 없을 때 로그인 → 401 + 에러 메시지", async () => {
@@ -144,7 +166,8 @@ describe("Auth Routes", () => {
 
       const body = response.json();
       expect(body.type).toBe("admin");
-      expect(body.email).toBe(TEST_ADMIN_USERNAME);
+      expect(body.username).toBe(TEST_ADMIN_USERNAME);
+      expect(body.email).toBeNull();
     });
 
     it("비로그인 → 401", async () => {


### PR DESCRIPTION
## Summary

Closes #78

Rename the admin local-auth persistence identifier from `email` to `username`, add a direct Drizzle migration for the column rename, and keep the current auth route payload stable while the external contract is migrated separately.

## Changes

| File | Change |
|------|--------|
| `src/db/schema/admins.ts` | Renamed the admin column mapping from `email` to `username`. |
| `src/routes/auth/admin.service.ts` | Switched credential lookup and auth errors to `username`. |
| `src/routes/auth/auth.route.ts` | Accepts username-style identifiers under the existing `email` field and maps response payloads back to `email` for compatibility. |
| `test/helpers/app.ts` | Replaced test admin fixture naming with `TEST_ADMIN_USERNAME`. |
| `test/helpers/seed.ts` | Seeds admins with `username` instead of `email`. |
| `test/routes/auth.test.ts` | Updated auth coverage to use usernames while keeping the route field name unchanged. |
| `drizzle/0008_admin_username.sql` | Adds the direct `admin_tb.email -> admin_tb.username` rename migration with binary collation and unique index rename. |
| `drizzle/meta/_journal.json` | Registers migration `0008_admin_username` so Drizzle actually applies it. |
| `scripts/hash-password.ts` | Updated manual SQL example to use `username`. |
| `scripts/README.md` | Updated admin creation/reset SQL examples to use `username`. |

## Verification

- `pnpm compile:types` ✅
- `pnpm build` ✅
- `pnpm test` ⚠️ unrelated existing failures remain in `test/routes/guestbook.test.ts`, `test/routes/stats.test.ts`, and `test/routes/health.test.ts`
- `pnpm lint` ⚠️ repo-wide existing baseline errors unrelated to this issue still fail the full command
