### PR TITLE
fix: enforce category and asset CSRF guards (#79)

### DIFF
--- a/src/routes/assets/asset.route.ts
+++ b/src/routes/assets/asset.route.ts
@@ -130,6 +130,7 @@ export function createAssetRoute(
     typedFastify.delete(
       "/bulk",
       {
+        onRequest: fastify.csrfProtection,
         preHandler: requireAdmin(adminService),
         schema: {
           tags: ["assets"],
@@ -159,6 +160,7 @@ export function createAssetRoute(
     typedFastify.delete(
       "/:id",
       {
+        onRequest: fastify.csrfProtection,
         preHandler: requireAdmin(adminService),
         schema: {
           tags: ["assets"],

--- a/src/routes/categories/category.route.ts
+++ b/src/routes/categories/category.route.ts
@@ -83,6 +83,7 @@ export function createCategoryRoute(
     typedFastify.post(
       "/",
       {
+        onRequest: fastify.csrfProtection,
         preHandler: requireAdmin(adminService),
         schema: {
           tags: ["categories"],
@@ -123,6 +124,7 @@ export function createCategoryRoute(
     typedFastify.patch(
       "/tree",
       {
+        onRequest: fastify.csrfProtection,
         preHandler: requireAdmin(adminService),
         schema: {
           tags: ["categories"],
@@ -152,6 +154,7 @@ export function createCategoryRoute(
     typedFastify.patch(
       "/:id",
       {
+        onRequest: fastify.csrfProtection,
         preHandler: requireAdmin(adminService),
         schema: {
           tags: ["categories"],
@@ -197,6 +200,7 @@ export function createCategoryRoute(
     typedFastify.delete(
       "/:id",
       {
+        onRequest: fastify.csrfProtection,
         preHandler: requireAdmin(adminService),
         schema: {
           tags: ["categories"],

--- a/test/routes/assets.test.ts
+++ b/test/routes/assets.test.ts
@@ -51,6 +51,20 @@ function buildMultipart(
   return Buffer.concat(parts);
 }
 
+function expectRouteHasOnRequestHook(
+  tree: string,
+  route: string,
+  method: "POST" | "DELETE",
+) {
+  const lines = tree.trimEnd().split("\n");
+  const routeIndex = lines.findIndex((line) =>
+    line.includes(`${route} (${method})`),
+  );
+
+  expect(routeIndex).toBeGreaterThanOrEqual(0);
+  expect(lines[routeIndex + 1]).toContain("• (onRequest)");
+}
+
 describe("Asset Routes", () => {
   let app: FastifyInstance;
   let authCookie: string;
@@ -121,6 +135,16 @@ describe("Asset Routes", () => {
       } catch {
         // 무시
       }
+    });
+
+    it("route에 CSRF onRequest hook 등록", () => {
+      const routes = app.printRoutes({
+        commonPrefix: false,
+        includeHooks: true,
+        method: "POST",
+      });
+
+      expectRouteHasOnRequestHook(routes, "/api/assets/upload", "POST");
     });
 
     it("인증 없이 → 403", async () => {
@@ -320,6 +344,16 @@ describe("Asset Routes", () => {
   // ===== DELETE /api/assets/:id =====
 
   describe("DELETE /api/assets/:id", () => {
+    it("route에 CSRF onRequest hook 등록", () => {
+      const routes = app.printRoutes({
+        commonPrefix: false,
+        includeHooks: true,
+        method: "DELETE",
+      });
+
+      expectRouteHasOnRequestHook(routes, "/api/assets/:id", "DELETE");
+    });
+
     it("인증 없이 → 403", async () => {
       const asset = await seedAsset();
       const res = await app.inject({
@@ -359,6 +393,16 @@ describe("Asset Routes", () => {
   // ===== DELETE /api/assets/bulk =====
 
   describe("DELETE /api/assets/bulk", () => {
+    it("route에 CSRF onRequest hook 등록", () => {
+      const routes = app.printRoutes({
+        commonPrefix: false,
+        includeHooks: true,
+        method: "DELETE",
+      });
+
+      expectRouteHasOnRequestHook(routes, "/api/assets/bulk", "DELETE");
+    });
+
     it("인증 없이 → 403", async () => {
       const res = await app.inject({
         method: "DELETE",

--- a/test/routes/categories.test.ts
+++ b/test/routes/categories.test.ts
@@ -11,6 +11,20 @@ import {
 import { db } from "@src/db/client";
 import { postTable } from "@src/db/schema";
 
+function expectRouteHasOnRequestHook(
+  tree: string,
+  route: string,
+  method: "POST" | "PATCH" | "DELETE",
+) {
+  const lines = tree.trimEnd().split("\n");
+  const routeIndex = lines.findIndex((line) =>
+    line.includes(`${route} (${method})`),
+  );
+
+  expect(routeIndex).toBeGreaterThanOrEqual(0);
+  expect(lines[routeIndex + 1]).toContain("• (onRequest)");
+}
+
 describe("Category Routes", () => {
   let app: FastifyInstance;
 
@@ -93,6 +107,16 @@ describe("Category Routes", () => {
   // ===== POST /api/categories =====
 
   describe("POST /api/categories", () => {
+    it("route에 CSRF onRequest hook 등록", () => {
+      const routes = app.printRoutes({
+        commonPrefix: false,
+        includeHooks: true,
+        method: "POST",
+      });
+
+      expectRouteHasOnRequestHook(routes, "/api/categories", "POST");
+    });
+
     it("Admin 생성 성공 → 201", async () => {
       await seedAdmin();
       const cookie = await injectAuth(app);
@@ -134,6 +158,16 @@ describe("Category Routes", () => {
   // ===== PATCH /api/categories/:id =====
 
   describe("PATCH /api/categories/:id", () => {
+    it("route에 CSRF onRequest hook 등록", () => {
+      const routes = app.printRoutes({
+        commonPrefix: false,
+        includeHooks: true,
+        method: "PATCH",
+      });
+
+      expectRouteHasOnRequestHook(routes, "/api/categories/:id", "PATCH");
+    });
+
     it("이름 변경", async () => {
       await seedAdmin();
       const cookie = await injectAuth(app);
@@ -159,6 +193,16 @@ describe("Category Routes", () => {
   // ===== PATCH /api/categories/tree =====
 
   describe("PATCH /api/categories/tree", () => {
+    it("route에 CSRF onRequest hook 등록", () => {
+      const routes = app.printRoutes({
+        commonPrefix: false,
+        includeHooks: true,
+        method: "PATCH",
+      });
+
+      expectRouteHasOnRequestHook(routes, "/api/categories/tree", "PATCH");
+    });
+
     it("트리 배치 변경 → 200", async () => {
       await seedAdmin();
       const cookie = await injectAuth(app);
@@ -258,6 +302,16 @@ describe("Category Routes", () => {
   // ===== DELETE /api/categories/:id =====
 
   describe("DELETE /api/categories/:id", () => {
+    it("route에 CSRF onRequest hook 등록", () => {
+      const routes = app.printRoutes({
+        commonPrefix: false,
+        includeHooks: true,
+        method: "DELETE",
+      });
+
+      expectRouteHasOnRequestHook(routes, "/api/categories/:id", "DELETE");
+    });
+
     it("하위 카테고리 있으면 409", async () => {
       await seedAdmin();
       const cookie = await injectAuth(app);


### PR DESCRIPTION
## Summary

Closes #79

Align category and asset admin mutation routes with the documented CSRF protection requirements.

## Changes

| File | Change |
|------|--------|
| `src/routes/categories/category.route.ts` | Added explicit `fastify.csrfProtection` on category create/update/delete admin routes that live outside `/api/admin/*`. |
| `src/routes/assets/asset.route.ts` | Added explicit `fastify.csrfProtection` on asset delete and bulk-delete routes. |
| `test/routes/categories.test.ts` | Added route introspection assertions to lock in CSRF hook registration for category mutation routes. |
| `test/routes/assets.test.ts` | Added route introspection assertions to lock in CSRF hook registration for asset mutation routes. |

## Screenshots

N/A
