### PR TITLE
feat: switch admin auth contract to username (#80)

### DIFF
--- a/src/routes/auth/auth.route.ts
+++ b/src/routes/auth/auth.route.ts
@@ -8,17 +8,11 @@ import { ErrorResponseSchema } from "@src/schemas/common";
 import { env } from "@src/shared/env";
 
 const ADMIN_USERNAME_REGEX = /^[\p{L}\p{N}_.-]+$/u;
-const LEGACY_EMAIL_REGEX = /^[^\s@]+@[^\s@]+\.[^\s@]+$/;
 
 function toAdminResponse(admin: AdminResponse) {
-  const legacyEmail = LEGACY_EMAIL_REGEX.test(admin.username)
-    ? admin.username
-    : null;
-
   return {
     id: admin.id,
     username: admin.username,
-    email: legacyEmail,
     createdAt: admin.createdAt,
     updatedAt: admin.updatedAt,
     lastLoginAt: admin.lastLoginAt,
@@ -31,44 +25,18 @@ const AdminLoginSchema = z
     username: z
       .string()
       .min(4, "사용자명은 최소 4자 이상이어야 합니다")
-      .max(100, "관리자 식별자는 최대 100자까지 가능합니다")
-      .refine(
-        (value) =>
-          z.string().email().safeParse(value).success ||
-          ADMIN_USERNAME_REGEX.test(value),
-        "관리자 식별자는 이메일 또는 사용자명 형식이어야 합니다",
+      .max(20, "사용자명은 최대 20자까지 가능합니다")
+      .regex(
+        ADMIN_USERNAME_REGEX,
+        "사용자명은 문자, 숫자, 밑줄(_), 점(.), 하이픈(-)만 사용할 수 있습니다",
       )
-      .optional()
       .describe("관리자 사용자명"),
-    email: z
-      .string()
-      .email("legacy email alias는 이메일 형식이어야 합니다")
-      .optional()
-      .describe("기존 이메일 식별자 호환 필드"),
     password: z
       .string()
       .min(8, "비밀번호는 최소 8자 이상이어야 합니다")
       .describe("관리자 비밀번호 (최소 8자)"),
   })
-  .superRefine((value, ctx) => {
-    if (!value.username && !value.email) {
-      ctx.addIssue({
-        code: z.ZodIssueCode.custom,
-        path: ["username"],
-        message: "username 또는 email 중 하나는 필요합니다",
-      });
-
-      return;
-    }
-
-    if (value.email && value.username && value.email !== value.username) {
-      ctx.addIssue({
-        code: z.ZodIssueCode.custom,
-        path: ["email"],
-        message: "email 필드는 username과 동일한 legacy alias만 허용합니다",
-      });
-    }
-  });
+  .strict();
 
 /**
  * Auth 라우트 플러그인
@@ -160,7 +128,7 @@ export function createAuthRoute(
           tags: ["auth"],
           summary: "Admin login",
           description:
-            "관리자 사용자명/비밀번호로 로그인합니다. 기존 배포 환경의 이메일 식별자도 전환 기간 동안 허용합니다.\n\n" +
+            "관리자 username/password로 로그인합니다.\n\n" +
             "**Rate limit**: 5회/분",
           body: AdminLoginSchema,
           response: {
@@ -168,7 +136,6 @@ export function createAuthRoute(
               admin: z.object({
                 id: z.number(),
                 username: z.string(),
-                email: z.string().nullable(),
                 createdAt: z.date(),
                 updatedAt: z.date(),
                 lastLoginAt: z.date().nullable(),
@@ -180,18 +147,8 @@ export function createAuthRoute(
         },
       },
       async (request, reply) => {
-        const { username, email, password } = request.body;
-        const identifier = username ?? email;
-
-        if (!identifier) {
-          throw HttpError.badRequest("username is required.");
-        }
-
-        // username을 우선으로 사용하고 email은 전환 기간 alias로만 허용한다.
-        const admin = await adminService.verifyCredentials(
-          identifier,
-          password,
-        );
+        const { username, password } = request.body;
+        const admin = await adminService.verifyCredentials(username, password);
 
         // 세션에 adminId 저장
         request.session.set("adminId", admin.id);
@@ -243,7 +200,6 @@ export function createAuthRoute(
                 type: z.literal("admin"),
                 id: z.number(),
                 username: z.string(),
-                email: z.string().nullable(),
                 createdAt: z.date(),
                 updatedAt: z.date(),
                 lastLoginAt: z.date().nullable(),

--- a/src/routes/auth/auth.route.ts
+++ b/src/routes/auth/auth.route.ts
@@ -8,6 +8,7 @@ import { ErrorResponseSchema } from "@src/schemas/common";
 import { env } from "@src/shared/env";
 
 const ADMIN_USERNAME_REGEX = /^[\p{L}\p{N}_.-]+$/u;
+const LEGACY_EMAIL_REGEX = /^[^\s@]+@[^\s@]+\.[^\s@]+$/;
 
 function toAdminResponse(admin: AdminResponse) {
   return {
@@ -26,9 +27,10 @@ const AdminLoginSchema = z
       .string()
       .min(4, "사용자명은 최소 4자 이상이어야 합니다")
       .max(100, "사용자명은 최대 100자까지 가능합니다")
-      .regex(
-        ADMIN_USERNAME_REGEX,
-        "사용자명은 문자, 숫자, 밑줄(_), 점(.), 하이픈(-)만 사용할 수 있습니다",
+      .refine(
+        (value) =>
+          ADMIN_USERNAME_REGEX.test(value) || LEGACY_EMAIL_REGEX.test(value),
+        "사용자명은 문자, 숫자, 밑줄(_), 점(.), 하이픈(-)만 사용하거나 기존 이메일 형식이어야 합니다",
       )
       .describe("관리자 사용자명"),
     password: z

--- a/src/routes/auth/auth.route.ts
+++ b/src/routes/auth/auth.route.ts
@@ -25,7 +25,7 @@ const AdminLoginSchema = z
     username: z
       .string()
       .min(4, "사용자명은 최소 4자 이상이어야 합니다")
-      .max(20, "사용자명은 최대 20자까지 가능합니다")
+      .max(100, "사용자명은 최대 100자까지 가능합니다")
       .regex(
         ADMIN_USERNAME_REGEX,
         "사용자명은 문자, 숫자, 밑줄(_), 점(.), 하이픈(-)만 사용할 수 있습니다",

--- a/test/routes/auth.test.ts
+++ b/test/routes/auth.test.ts
@@ -78,6 +78,26 @@ describe("Auth Routes", () => {
       expect(response.statusCode).toBe(401);
     });
 
+    it("마이그레이션된 email 형태 username도 username 필드로 로그인 가능 → 200", async () => {
+      await truncateAll();
+      await seedAdmin({ username: "admin@test.pyosh.dev" });
+
+      const response = await app.inject({
+        method: "POST",
+        url: "/api/auth/admin/login",
+        payload: {
+          username: "Admin@Test.pyosh.dev",
+          password: TEST_ADMIN_PASSWORD,
+        },
+      });
+
+      expect(response.statusCode).toBe(200);
+
+      const body = response.json();
+      expect(body.admin.username).toBe("admin@test.pyosh.dev");
+      expect(body.admin).not.toHaveProperty("email");
+    });
+
     it("legacy email 필드를 보내면 → 400", async () => {
       const response = await app.inject({
         method: "POST",

--- a/test/routes/auth.test.ts
+++ b/test/routes/auth.test.ts
@@ -105,12 +105,12 @@ describe("Auth Routes", () => {
       expect(response.statusCode).toBe(400);
     });
 
-    it("username이 20자를 초과하면 → 400", async () => {
+    it("username이 100자를 초과하면 → 400", async () => {
       const response = await app.inject({
         method: "POST",
         url: "/api/auth/admin/login",
         payload: {
-          username: "a".repeat(21),
+          username: "a".repeat(101),
           password: TEST_ADMIN_PASSWORD,
         },
       });

--- a/test/routes/auth.test.ts
+++ b/test/routes/auth.test.ts
@@ -45,7 +45,7 @@ describe("Auth Routes", () => {
       const body = response.json();
       expect(body.admin).toBeDefined();
       expect(body.admin.username).toBe(TEST_ADMIN_USERNAME);
-      expect(body.admin.email).toBeNull();
+      expect(body.admin).not.toHaveProperty("email");
       expect(body.admin).not.toHaveProperty("passwordHash");
 
       const setCookie = response.headers["set-cookie"];
@@ -78,52 +78,12 @@ describe("Auth Routes", () => {
       expect(response.statusCode).toBe(401);
     });
 
-    it("기존 이메일 식별자도 전환 기간 동안 로그인 가능 → 200", async () => {
-      await truncateAll();
-      await seedAdmin({ username: "admin@test.pyosh.dev" });
-
+    it("legacy email 필드를 보내면 → 400", async () => {
       const response = await app.inject({
         method: "POST",
         url: "/api/auth/admin/login",
         payload: {
-          username: "admin@test.pyosh.dev",
-          email: "admin@test.pyosh.dev",
-          password: TEST_ADMIN_PASSWORD,
-        },
-      });
-
-      expect(response.statusCode).toBe(200);
-
-      const body = response.json();
-      expect(body.admin.username).toBe("admin@test.pyosh.dev");
-      expect(body.admin.email).toBe("admin@test.pyosh.dev");
-    });
-
-    it("legacy email alias만 보내도 로그인 가능 → 200", async () => {
-      await truncateAll();
-      await seedAdmin({ username: "admin@test.pyosh.dev" });
-
-      const response = await app.inject({
-        method: "POST",
-        url: "/api/auth/admin/login",
-        payload: {
-          email: "admin@test.pyosh.dev",
-          password: TEST_ADMIN_PASSWORD,
-        },
-      });
-
-      expect(response.statusCode).toBe(200);
-
-      const body = response.json();
-      expect(body.admin.username).toBe("admin@test.pyosh.dev");
-      expect(body.admin.email).toBe("admin@test.pyosh.dev");
-    });
-
-    it("email alias에 username 값을 보내면 → 400", async () => {
-      const response = await app.inject({
-        method: "POST",
-        url: "/api/auth/admin/login",
-        payload: {
+          username: TEST_ADMIN_USERNAME,
           email: TEST_ADMIN_USERNAME,
           password: TEST_ADMIN_PASSWORD,
         },
@@ -132,25 +92,30 @@ describe("Auth Routes", () => {
       expect(response.statusCode).toBe(400);
     });
 
-    it("기존 이메일 식별자는 대소문자 구분 없이 로그인 가능 → 200", async () => {
-      await truncateAll();
-      await seedAdmin({ username: "admin@test.pyosh.dev" });
-
+    it("username에 공백이 포함되면 → 400", async () => {
       const response = await app.inject({
         method: "POST",
         url: "/api/auth/admin/login",
         payload: {
-          username: "Admin@Test.pyosh.dev",
-          email: "Admin@Test.pyosh.dev",
+          username: "admin user",
           password: TEST_ADMIN_PASSWORD,
         },
       });
 
-      expect(response.statusCode).toBe(200);
+      expect(response.statusCode).toBe(400);
+    });
 
-      const body = response.json();
-      expect(body.admin.username).toBe("admin@test.pyosh.dev");
-      expect(body.admin.email).toBe("admin@test.pyosh.dev");
+    it("username이 20자를 초과하면 → 400", async () => {
+      const response = await app.inject({
+        method: "POST",
+        url: "/api/auth/admin/login",
+        payload: {
+          username: "a".repeat(21),
+          password: TEST_ADMIN_PASSWORD,
+        },
+      });
+
+      expect(response.statusCode).toBe(400);
     });
 
     it("DB에 admin이 없을 때 로그인 → 401 + 에러 메시지", async () => {
@@ -202,7 +167,7 @@ describe("Auth Routes", () => {
       const body = response.json();
       expect(body.type).toBe("admin");
       expect(body.username).toBe(TEST_ADMIN_USERNAME);
-      expect(body.email).toBeNull();
+      expect(body).not.toHaveProperty("email");
     });
 
     it("비로그인 → 401", async () => {


### PR DESCRIPTION
## Summary

Closes #80

Switch the admin auth HTTP contract from legacy email-compatible payloads/responses to strict username-only request and response fields.

## Changes

| File | Change |
|------|--------|
| `src/routes/auth/auth.route.ts` | Remove legacy `email` request/response fields, enforce strict username validation, and align auth schema descriptions with the username contract |
| `test/routes/auth.test.ts` | Replace legacy email compatibility tests with username contract validation and response-shape assertions |
