### PR TITLE
fix: generate published summary (#84)

### DIFF
--- a/src/routes/posts/post.service.ts
+++ b/src/routes/posts/post.service.ts
@@ -34,7 +34,55 @@ const MAX_PINNED_POSTS = 5;
 const PINNED_POST_LIMIT_ERROR =
   "Pinned post limit exceeded. Maximum 5 pinned posts allowed.";
 const PINNED_POST_LIMIT_LOCK_NAME = "post_pinned_limit";
+const SUMMARY_MAX_LENGTH = 200;
 type NamedLockRow = RowDataPacket & { acquired: number | null };
+
+function extractPlainText(markdown: string, maxLength = SUMMARY_MAX_LENGTH) {
+  const plainText = markdown
+    .replace(/```[\s\S]*?```/g, " ")
+    .replace(/`([^`]+)`/g, "$1")
+    .replace(/!\[([^\]]*)\]\([^)]+\)/g, "$1")
+    .replace(/\[([^\]]+)\]\([^)]+\)/g, "$1")
+    .replace(/^#{1,6}\s+/gm, "")
+    .replace(/^\s*[-*+]\s+/gm, "")
+    .replace(/^\s*\d+\.\s+/gm, "")
+    .replace(/[>*_~]/g, "")
+    .replace(/\n+/g, " ")
+    .replace(/\s+/g, " ")
+    .trim();
+
+  if (plainText.length <= maxLength) {
+    return plainText;
+  }
+
+  const ellipsis = "...";
+  const safeLimit = Math.max(maxLength - ellipsis.length, 0);
+
+  if (safeLimit === 0) {
+    return ellipsis.slice(0, maxLength);
+  }
+
+  return `${plainText.slice(0, safeLimit).trimEnd()}${ellipsis}`;
+}
+
+function normalizeSummary(summary: string | null | undefined) {
+  const trimmed = summary?.trim();
+  return trimmed ? trimmed : null;
+}
+
+function resolvePublishedSummary(input: {
+  status: "draft" | "published" | "archived";
+  summary: string | null | undefined;
+  contentMd: string;
+}) {
+  const normalizedSummary = normalizeSummary(input.summary);
+
+  if (input.status !== "published") {
+    return normalizedSummary;
+  }
+
+  return normalizedSummary ?? extractPlainText(input.contentMd);
+}
 
 /**
  * 게시글 생성 입력 데이터
@@ -220,7 +268,11 @@ export class PostService {
           slug,
           contentMd: input.contentMd,
           categoryId: input.categoryId,
-          summary: input.summary ?? null,
+          summary: resolvePublishedSummary({
+            status: input.status ?? "draft",
+            summary: input.summary,
+            contentMd: input.contentMd,
+          }),
           description: input.description ?? null,
           thumbnailUrl: input.thumbnailUrl ?? null,
           visibility: input.visibility ?? "public",
@@ -283,11 +335,30 @@ export class PostService {
           throw HttpError.notFound("Post not found.");
         }
 
+        const nextStatus = input.status ?? existing[0].status;
+        const nextContentMd = input.contentMd ?? existing[0].contentMd;
+        const nextSummary =
+          input.summary !== undefined ? input.summary : existing[0].summary;
+        const nextPublishedAt =
+          input.publishedAt !== undefined
+            ? input.publishedAt
+            : existing[0].publishedAt;
+
         // 2. 게시글 수정
         const updateData: Partial<NewPost> = {
           ...input,
           updatedAt: new Date(),
         };
+
+        updateData.summary = resolvePublishedSummary({
+          status: nextStatus,
+          summary: nextSummary,
+          contentMd: nextContentMd,
+        });
+
+        if (nextStatus === "published" && !nextPublishedAt) {
+          updateData.publishedAt = new Date();
+        }
 
         // contentMd가 변경되면 contentModifiedAt 자동 갱신
         if (input.contentMd !== undefined) {

--- a/test/routes/posts.test.ts
+++ b/test/routes/posts.test.ts
@@ -204,6 +204,30 @@ describe("Post Routes", () => {
       expect(body.post.publishedAt).not.toBeNull();
     });
 
+    it("status=published + summary 없음 → contentMd 기반 summary 자동 생성 → 201", async () => {
+      await seedAdmin();
+      const cookie = await injectAuth(app);
+      const category = await seedCategory();
+
+      const response = await app.inject({
+        method: "POST",
+        url: "/api/admin/posts",
+        headers: { cookie },
+        payload: {
+          title: "Auto Summary",
+          contentMd:
+            "# Heading\n\n본문 **요약** 문장과 [링크](https://example.com)가 포함됩니다.",
+          categoryId: category.id,
+          status: "published",
+        },
+      });
+
+      expect(response.statusCode).toBe(201);
+      expect(response.json().post.summary).toBe(
+        "Heading 본문 요약 문장과 링크가 포함됩니다.",
+      );
+    });
+
     it("6번째 pinned 생성 시도는 409 반환", async () => {
       await seedAdmin();
       const cookie = await injectAuth(app);
@@ -543,6 +567,54 @@ describe("Post Routes", () => {
       expect(response.statusCode).toBe(200);
       const body = response.json();
       expect(body.post.contentModifiedAt).not.toBeNull();
+    });
+
+    it("draft에서 published 전환 시 summary가 없으면 자동 생성 → 200", async () => {
+      await seedAdmin();
+      const cookie = await injectAuth(app);
+      const category = await seedCategory();
+      const post = await seedPost(category.id, {
+        status: "draft",
+        summary: null,
+        contentMd: "# Draft Title\n\n전환 시 요약을 자동 생성합니다.",
+        publishedAt: null,
+      });
+
+      const response = await app.inject({
+        method: "PATCH",
+        url: `/api/admin/posts/${post.id}`,
+        headers: { cookie },
+        payload: { status: "published" },
+      });
+
+      expect(response.statusCode).toBe(200);
+      expect(response.json().post.summary).toBe(
+        "Draft Title 전환 시 요약을 자동 생성합니다.",
+      );
+      expect(response.json().post.publishedAt).not.toBeNull();
+    });
+
+    it("published 글에서 summary를 null로 비우면 contentMd 기반으로 다시 생성 → 200", async () => {
+      await seedAdmin();
+      const cookie = await injectAuth(app);
+      const category = await seedCategory();
+      const post = await seedPost(category.id, {
+        status: "published",
+        summary: "기존 요약",
+        contentMd: "# Updated\n\nsummary regenerated from content.",
+      });
+
+      const response = await app.inject({
+        method: "PATCH",
+        url: `/api/admin/posts/${post.id}`,
+        headers: { cookie },
+        payload: { summary: null },
+      });
+
+      expect(response.statusCode).toBe(200);
+      expect(response.json().post.summary).toBe(
+        "Updated summary regenerated from content.",
+      );
     });
 
     it("tags=[] 전달 시 태그 전체 제거 → 200", async () => {


### PR DESCRIPTION
## Summary

Closes #84

Ensure published posts always persist a server-generated `summary` when one is missing, so list responses remain safe without relying on client-side `contentMd` extraction.

## Changes

| File | Change |
|------|--------|
| `src/routes/posts/post.service.ts` | Added shared markdown-to-plain-text summary extraction and applied it on create/update whenever a post is saved as `published` without a summary; also auto-fills `publishedAt` on draft → published transitions when missing. |
| `test/routes/posts.test.ts` | Added coverage for published create auto-summary, draft → published auto-summary, and published summary regeneration after clearing the field. |

## Verification

- `pnpm test --run test/routes/posts.test.ts` ✅
- `pnpm test` ⚠️ fails on existing base-branch issues unrelated to this change:
  - `test/routes/guestbook.test.ts` (`관리자 강제 삭제 → 204` gets `400`)
  - `test/routes/stats.test.ts` (`같은 IP, 다른 대상(글 vs 사이트) → 중복 아님`)
  - `test/routes/health.test.ts` (`Pool is closed`)

