### PR TITLE
fix: align uploads static path (#88)

### DIFF
--- a/src/plugins/static.ts
+++ b/src/plugins/static.ts
@@ -1,25 +1,28 @@
-import * as path from "path";
+import * as fs from "fs/promises";
 import fastifyStatic from "@fastify/static";
 import { FastifyInstance } from "fastify";
 import fastifyPlugin from "fastify-plugin";
+import { getUploadDir, UPLOADS_URL_PREFIX } from "@src/shared/uploads";
 
 /**
  * Static 파일 서빙 플러그인
  * uploads 디렉토리의 파일을 /uploads/ 경로로 서빙
  */
 async function staticPlugin(fastify: FastifyInstance) {
-  const uploadDir =
-    process.env.UPLOAD_DIR || path.join(process.cwd(), "uploads");
+  const uploadDir = getUploadDir();
+  await fs.mkdir(uploadDir, { recursive: true });
 
   await fastify.register(fastifyStatic, {
     root: uploadDir,
-    prefix: "/uploads/",
+    prefix: UPLOADS_URL_PREFIX,
     decorateReply: false,
     maxAge: 30 * 24 * 60 * 60 * 1000, // 30일 (밀리초)
     immutable: true,
   });
 
-  fastify.log.info(`Static files serving from: ${uploadDir} at /uploads/`);
+  fastify.log.info(
+    `Static files serving from: ${uploadDir} at ${UPLOADS_URL_PREFIX}`,
+  );
 }
 
 export default fastifyPlugin(staticPlugin, {

--- a/src/routes/assets/asset.service.ts
+++ b/src/routes/assets/asset.service.ts
@@ -4,6 +4,7 @@ import { assetTable, type Asset } from "@src/db/schema/assets";
 import * as schema from "@src/db/schema/index";
 import { HttpError } from "@src/errors/http-error";
 import { FileStorageService, type BufferedFile } from "@src/services/file-storage.service";
+import { toUploadUrl, UPLOADS_URL_PREFIX } from "@src/shared/uploads";
 import {
   buildPaginatedResponse,
   calculateOffset,
@@ -112,7 +113,7 @@ export class AssetService {
 
     // 2. 실제 파일 삭제 (실패해도 DB는 삭제)
     try {
-      await this.fileStorage.deleteFile(asset.url.replace("/uploads/", ""));
+      await this.fileStorage.deleteFile(asset.url.replace(UPLOADS_URL_PREFIX, ""));
     } catch (error) {
       // 파일 삭제 실패는 로그만 남기고 계속 진행
       console.error(`Failed to delete file: ${asset.url}`, error);
@@ -184,7 +185,7 @@ export class AssetService {
   private toUploadedAsset(asset: Asset): UploadedAsset {
     return {
       id: asset.id,
-      url: `/uploads/${asset.storageKey}`,
+      url: toUploadUrl(asset.storageKey),
       mimeType: asset.mimeType,
       sizeBytes: asset.sizeBytes,
       width: asset.width ?? undefined,

--- a/src/services/file-storage.service.ts
+++ b/src/services/file-storage.service.ts
@@ -4,12 +4,12 @@ import * as path from "path";
 import { imageSize } from "image-size";
 import type { MultipartFile } from "@fastify/multipart";
 import { HttpError } from "@src/errors/http-error";
+import { getUploadDir } from "@src/shared/uploads";
 
 /**
  * 파일 저장 설정 상수
  */
-const UPLOAD_DIR =
-  process.env.UPLOAD_DIR || path.join(process.cwd(), "uploads");
+const UPLOAD_DIR = getUploadDir();
 const ALLOWED_MIME_TYPES = [
   "image/jpeg",
   "image/png",
@@ -217,7 +217,7 @@ export class FileStorageService {
     await fs.writeFile(filePath, buffer);
 
     // 8. 상대 경로 반환 (storageKey)
-    const storageKey = path.join(year, month, fileName);
+    const storageKey = path.posix.join(year, month, fileName);
 
     // 9. 이미지 크기 추출 (SVG 등 추출 불가 시 undefined)
     let width: number | undefined;

--- a/src/shared/uploads.ts
+++ b/src/shared/uploads.ts
@@ -1,0 +1,11 @@
+import * as path from "path";
+
+export const UPLOADS_URL_PREFIX = "/uploads/";
+
+export function getUploadDir(): string {
+  return process.env.UPLOAD_DIR || path.join(process.cwd(), "uploads");
+}
+
+export function toUploadUrl(storageKey: string): string {
+  return `${UPLOADS_URL_PREFIX}${storageKey.replace(/\\/g, "/")}`;
+}

--- a/test/routes/assets.test.ts
+++ b/test/routes/assets.test.ts
@@ -2,6 +2,7 @@ import * as fs from "fs/promises";
 import * as path from "path";
 import { FastifyInstance } from "fastify";
 import { describe, it, expect, beforeAll, afterAll, beforeEach, afterEach, vi } from "vitest";
+import { getUploadDir } from "@src/shared/uploads";
 import { createTestApp, cleanup, injectAuth } from "@test/helpers/app";
 import { seedAdmin, seedAsset, truncateAll } from "@test/helpers/seed";
 
@@ -128,8 +129,7 @@ describe("Asset Routes", () => {
   describe("POST /api/assets/upload", () => {
     afterEach(async () => {
       // 업로드된 파일 정리
-      const uploadDir =
-        process.env.UPLOAD_DIR || path.join(process.cwd(), "uploads");
+      const uploadDir = getUploadDir();
       try {
         await fs.rm(uploadDir, { recursive: true, force: true });
       } catch {
@@ -185,6 +185,40 @@ describe("Asset Routes", () => {
       expect(asset.url).toMatch(/^\/uploads\/\d{4}\/\d{2}\//);
       expect(asset.width).toBe(1);
       expect(asset.height).toBe(1);
+    });
+
+    it("업로드 후 반환된 /uploads URL로 정적 접근 가능", async () => {
+      const boundary = "testboundary";
+      const payload = buildMultipart(
+        [{ fieldName: "files", fileName: "served.png", content: TINY_PNG, mimeType: "image/png" }],
+        boundary,
+      );
+      const uploadRes = await app.inject({
+        method: "POST",
+        url: "/api/assets/upload",
+        headers: {
+          cookie: authCookie,
+          "content-type": `multipart/form-data; boundary=${boundary}`,
+        },
+        payload,
+      });
+
+      expect(uploadRes.statusCode).toBe(201);
+      const body = uploadRes.json();
+      const asset = body.assets[0];
+      const relativePath = asset.url.replace(/^\/uploads\//, "");
+      const savedFile = path.join(getUploadDir(), relativePath);
+
+      await expect(fs.access(savedFile)).resolves.toBeUndefined();
+
+      const staticRes = await app.inject({
+        method: "GET",
+        url: asset.url,
+      });
+
+      expect(staticRes.statusCode).toBe(200);
+      expect(staticRes.headers["content-type"]).toContain("image/png");
+      expect(Number(staticRes.headers["content-length"])).toBe(TINY_PNG.length);
     });
 
     it("안전한 SVG 업로드 → 201", async () => {


### PR DESCRIPTION
## Summary

Closes #88

업로드 저장 경로와 `/uploads/*` 정적 서빙 경로를 공통 resolver로 맞추고, 업로드 후 반환된 상대 URL이 실제 정적 파일 접근으로 이어지는지 테스트를 추가합니다.

## Changes

| File | Change |
|------|--------|
| `src/shared/uploads.ts` | 업로드 디렉토리와 `/uploads/` URL prefix를 공통으로 해석하는 helper 추가 |
| `src/plugins/static.ts` | 공통 upload dir 사용 및 서버 시작 시 업로드 디렉토리 선생성 |
| `src/services/file-storage.service.ts` | 공통 upload dir 사용, storageKey를 POSIX 경로로 고정 |
| `src/routes/assets/asset.service.ts` | 업로드 URL 생성/삭제 시 공통 prefix helper 사용 |
| `test/routes/assets.test.ts` | 업로드 후 저장 파일 존재와 `/uploads/...` 정적 접근 성공 검증 추가 |

## Screenshots

