### PR TITLE
feat: support unicode post slugs (#92)

### DIFF
--- a/drizzle/0009_fix_invalid_post_slugs.sql
+++ b/drizzle/0009_fix_invalid_post_slugs.sql
@@ -1,5 +1,5 @@
 UPDATE `post_tb`
-SET `slug` = CONCAT('__repair__', `id`, '__', REPLACE(UUID(), '-', ''))
+SET `slug` = CONCAT('~repair~', `id`, '~', REPLACE(UUID(), '-', ''))
 WHERE TRIM(COALESCE(`slug`, '')) = ''
    OR `slug` REGEXP '^-[0-9]+$';--> statement-breakpoint
 
@@ -19,4 +19,4 @@ SET `slug` = (
     )
   END
 )
-WHERE `target`.`slug` REGEXP '^__repair__';
+WHERE `target`.`slug` REGEXP '^~repair~[0-9]+~';

--- a/drizzle/0009_fix_invalid_post_slugs.sql
+++ b/drizzle/0009_fix_invalid_post_slugs.sql
@@ -1,0 +1,4 @@
+UPDATE `post_tb`
+SET `slug` = CAST(`id` AS CHAR)
+WHERE TRIM(COALESCE(`slug`, '')) = ''
+   OR `slug` REGEXP '^-[0-9]+$';

--- a/drizzle/0009_fix_invalid_post_slugs.sql
+++ b/drizzle/0009_fix_invalid_post_slugs.sql
@@ -1,4 +1,22 @@
 UPDATE `post_tb`
-SET `slug` = CAST(`id` AS CHAR)
+SET `slug` = CONCAT('__repair__', `id`, '__', REPLACE(UUID(), '-', ''))
 WHERE TRIM(COALESCE(`slug`, '')) = ''
-   OR `slug` REGEXP '^-[0-9]+$';
+   OR `slug` REGEXP '^-[0-9]+$';--> statement-breakpoint
+
+UPDATE `post_tb` AS `target`
+SET `slug` = (
+  CASE
+    WHEN NOT EXISTS (
+      SELECT 1
+      FROM `post_tb` AS `other`
+      WHERE `other`.`slug` = CAST(`target`.`id` AS CHAR)
+        AND `other`.`id` <> `target`.`id`
+    ) THEN CAST(`target`.`id` AS CHAR)
+    ELSE CONCAT(
+      CAST(`target`.`id` AS CHAR),
+      '-legacy-',
+      LOWER(REPLACE(UUID(), '-', ''))
+    )
+  END
+)
+WHERE `target`.`slug` REGEXP '^__repair__';

--- a/drizzle/meta/_journal.json
+++ b/drizzle/meta/_journal.json
@@ -64,6 +64,13 @@
       "when": 1775476800000,
       "tag": "0008_admin_username",
       "breakpoints": true
+    },
+    {
+      "idx": 9,
+      "version": "5",
+      "when": 1776124800000,
+      "tag": "0009_fix_invalid_post_slugs",
+      "breakpoints": true
     }
   ]
 }

--- a/src/routes/posts/post.service.ts
+++ b/src/routes/posts/post.service.ts
@@ -28,7 +28,7 @@ import {
   buildPaginatedResponse,
   calculateOffset,
 } from "@src/shared/pagination";
-import { generateSlug, isBlankSlug } from "@src/shared/slug";
+import { ensureUniqueSlug, generateSlug, isBlankSlug } from "@src/shared/slug";
 
 const MAX_PINNED_POSTS = 5;
 const PINNED_POST_LIMIT_ERROR =
@@ -1066,7 +1066,7 @@ export class PostService {
     const preferredSlug = generateSlug(title);
 
     if (isBlankSlug(preferredSlug)) {
-      return String(postId);
+      return await this.resolveFallbackSlug(tx, postId, excludeId);
     }
 
     const existing = await tx
@@ -1079,7 +1079,29 @@ export class PostService {
       return preferredSlug;
     }
 
-    return String(postId);
+    return await this.resolveFallbackSlug(tx, postId, excludeId);
+  }
+
+  private async resolveFallbackSlug(
+    tx: MySql2Database<typeof schema>,
+    postId: number,
+    excludeId?: number,
+  ): Promise<string> {
+    const baseSlug = String(postId);
+
+    return await ensureUniqueSlug(baseSlug, async (checkSlug) => {
+      const existing = await tx
+        .select({ id: postTable.id })
+        .from(postTable)
+        .where(eq(postTable.slug, checkSlug))
+        .limit(1);
+
+      if (existing.length === 0) {
+        return false;
+      }
+
+      return excludeId === undefined || existing[0]?.id !== excludeId;
+    });
   }
 
   /**

--- a/src/routes/posts/post.service.ts
+++ b/src/routes/posts/post.service.ts
@@ -74,6 +74,14 @@ function normalizeSummary(summary: string | null | undefined) {
   return trimmed ? trimmed : null;
 }
 
+function needsLegacySlugRepair(slug: string | null | undefined) {
+  if (isBlankSlug(slug)) {
+    return true;
+  }
+
+  return /^-[0-9]+$/.test(slug.trim());
+}
+
 function resolvePublishedSummary(input: {
   status: "draft" | "published" | "archived";
   summary: string | null | undefined;
@@ -343,7 +351,7 @@ export class PostService {
           input.publishedAt !== undefined
             ? input.publishedAt
             : existing[0].publishedAt;
-        const needsSlugRepair = isBlankSlug(existing[0].slug);
+        const needsSlugRepair = needsLegacySlugRepair(existing[0].slug);
 
         // 2. 게시글 수정
         const updateData: Partial<NewPost> = {

--- a/src/routes/posts/post.service.ts
+++ b/src/routes/posts/post.service.ts
@@ -28,7 +28,11 @@ import {
   buildPaginatedResponse,
   calculateOffset,
 } from "@src/shared/pagination";
-import { ensureUniqueSlug, generateSlug, isBlankSlug } from "@src/shared/slug";
+import {
+  ensureUniqueSlug,
+  generateUnicodeSlug,
+  isBlankSlug,
+} from "@src/shared/slug";
 
 const MAX_PINNED_POSTS = 5;
 const PINNED_POST_LIMIT_ERROR =
@@ -1063,7 +1067,7 @@ export class PostService {
     postId: number,
     excludeId?: number,
   ): Promise<string> {
-    const preferredSlug = generateSlug(title);
+    const preferredSlug = generateUnicodeSlug(title);
 
     if (isBlankSlug(preferredSlug)) {
       return await this.resolveFallbackSlug(tx, postId, excludeId);

--- a/src/routes/posts/post.service.ts
+++ b/src/routes/posts/post.service.ts
@@ -28,7 +28,7 @@ import {
   buildPaginatedResponse,
   calculateOffset,
 } from "@src/shared/pagination";
-import { generateSlug, ensureUniqueSlug } from "@src/shared/slug";
+import { generateSlug, isBlankSlug } from "@src/shared/slug";
 
 const MAX_PINNED_POSTS = 5;
 const PINNED_POST_LIMIT_ERROR =
@@ -244,28 +244,16 @@ export class PostService {
           : [];
 
       return await this.db.transaction(async (tx) => {
-        // 1. slug 생성 및 중복 확인
-        const baseSlug = generateSlug(input.title);
-        const slug = await ensureUniqueSlug(baseSlug, async (checkSlug) => {
-          const existing = await tx
-            .select()
-            .from(postTable)
-            .where(eq(postTable.slug, checkSlug))
-            .limit(1);
-
-          return existing.length > 0;
-        });
-
-        // 2. status가 'published'이고 publishedAt이 없으면 자동 설정
+        // 1. status가 'published'이고 publishedAt이 없으면 자동 설정
         let publishedAt = input.publishedAt;
         if (input.status === "published" && !publishedAt) {
           publishedAt = new Date();
         }
 
-        // 3. 게시글 생성
+        // 2. 게시글 생성
         const newPost: NewPost = {
           title: input.title,
-          slug,
+          slug: this.buildPendingSlug(),
           contentMd: input.contentMd,
           categoryId: input.categoryId,
           summary: resolvePublishedSummary({
@@ -283,16 +271,24 @@ export class PostService {
         };
 
         const [result] = await tx.insert(postTable).values(newPost);
-        const postId = result.insertId;
+        const postId = Number(result.insertId);
 
-        // 4. 태그 연결
+        const resolvedSlug = await this.resolvePostSlug(tx, input.title, postId);
+        if (resolvedSlug !== newPost.slug) {
+          await tx
+            .update(postTable)
+            .set({ slug: resolvedSlug })
+            .where(eq(postTable.id, postId));
+        }
+
+        // 3. 태그 연결
         if (tagIds.length > 0) {
           await tx
             .insert(postTagTable)
             .values(tagIds.map((tagId) => ({ postId, tagId })));
         }
 
-        // 5. 생성된 게시글 전체 조회
+        // 4. 생성된 게시글 전체 조회
         return await this.getPostByIdInternal(postId, tx);
       });
     };
@@ -343,6 +339,7 @@ export class PostService {
           input.publishedAt !== undefined
             ? input.publishedAt
             : existing[0].publishedAt;
+        const needsSlugRepair = isBlankSlug(existing[0].slug);
 
         // 2. 게시글 수정
         const updateData: Partial<NewPost> = {
@@ -363,6 +360,15 @@ export class PostService {
         // contentMd가 변경되면 contentModifiedAt 자동 갱신
         if (input.contentMd !== undefined) {
           updateData.contentModifiedAt = new Date();
+        }
+
+        if (needsSlugRepair) {
+          updateData.slug = await this.resolvePostSlug(
+            tx,
+            input.title ?? existing[0].title,
+            id,
+            id,
+          );
         }
 
         await tx.update(postTable).set(updateData).where(eq(postTable.id, id));
@@ -1045,6 +1051,35 @@ export class PostService {
         commentCount: commentMap.get(post.id) ?? 0,
       };
     });
+  }
+
+  private buildPendingSlug(): string {
+    return `__pending__${Date.now()}-${Math.random().toString(36).slice(2, 10)}`;
+  }
+
+  private async resolvePostSlug(
+    tx: MySql2Database<typeof schema>,
+    title: string,
+    postId: number,
+    excludeId?: number,
+  ): Promise<string> {
+    const preferredSlug = generateSlug(title);
+
+    if (isBlankSlug(preferredSlug)) {
+      return String(postId);
+    }
+
+    const existing = await tx
+      .select({ id: postTable.id })
+      .from(postTable)
+      .where(eq(postTable.slug, preferredSlug))
+      .limit(1);
+
+    if (existing.length === 0 || existing[0]?.id === excludeId) {
+      return preferredSlug;
+    }
+
+    return String(postId);
   }
 
   /**

--- a/src/shared/slug.ts
+++ b/src/shared/slug.ts
@@ -1,20 +1,19 @@
 /**
- * 텍스트를 URL path에 넣을 수 있는 unicode slug로 변환
+ * 텍스트를 URL-safe한 ASCII slug로 변환
  * @param text 원본 텍스트
  * @returns slug 문자열
  *
  * @example
  * generateSlug("Hello World!") // "hello-world"
- * generateSlug("한글 제목 테스트") // "한글-제목-테스트"
+ * generateSlug("My Blog Post 2024") // "my-blog-post-2024"
  */
 export function generateSlug(text: string): string {
   return (
     text
-      .normalize("NFKC")
       .toLowerCase()
       .trim()
-      // URL path에서 의미가 큰 예약 문자와 일반 구두점을 제거
-      .replace(/[^\p{L}\p{N}\s_-]+/gu, "")
+      // 특수문자를 하이픈으로 변환
+      .replace(/[^\w\s-]/g, "")
       // 공백을 하이픈으로 변환
       .replace(/\s+/g, "-")
       // 연속된 하이픈을 하나로
@@ -26,6 +25,19 @@ export function generateSlug(text: string): string {
 
 export function isBlankSlug(slug: string | null | undefined): boolean {
   return slug === undefined || slug === null || slug.trim().length === 0;
+}
+
+export function generateUnicodeSlug(text: string): string {
+  return (
+    text
+      .normalize("NFKC")
+      .toLowerCase()
+      .trim()
+      .replace(/[^\p{L}\p{N}\s_-]+/gu, "")
+      .replace(/\s+/g, "-")
+      .replace(/-+/g, "-")
+      .replace(/^-+|-+$/g, "")
+  );
 }
 
 /**

--- a/src/shared/slug.ts
+++ b/src/shared/slug.ts
@@ -1,19 +1,20 @@
 /**
- * 텍스트를 URL-safe한 slug로 변환
+ * 텍스트를 URL path에 넣을 수 있는 unicode slug로 변환
  * @param text 원본 텍스트
  * @returns slug 문자열
  *
  * @example
  * generateSlug("Hello World!") // "hello-world"
- * generateSlug("My Blog Post 2024") // "my-blog-post-2024"
+ * generateSlug("한글 제목 테스트") // "한글-제목-테스트"
  */
 export function generateSlug(text: string): string {
   return (
     text
+      .normalize("NFKC")
       .toLowerCase()
       .trim()
-      // 특수문자를 하이픈으로 변환
-      .replace(/[^\w\s-]/g, "")
+      // URL path에서 의미가 큰 예약 문자와 일반 구두점을 제거
+      .replace(/[^\p{L}\p{N}\s_-]+/gu, "")
       // 공백을 하이픈으로 변환
       .replace(/\s+/g, "-")
       // 연속된 하이픈을 하나로
@@ -21,6 +22,10 @@ export function generateSlug(text: string): string {
       // 앞뒤 하이픈 제거
       .replace(/^-+|-+$/g, "")
   );
+}
+
+export function isBlankSlug(slug: string | null | undefined): boolean {
+  return slug === undefined || slug === null || slug.trim().length === 0;
 }
 
 /**

--- a/test/routes/posts.test.ts
+++ b/test/routes/posts.test.ts
@@ -848,6 +848,26 @@ describe("Post Routes", () => {
       expect(response.statusCode).toBe(200);
       expect(response.json().post.slug).toBe("복구된-제목");
     });
+
+    it("legacy -숫자 slug 글을 수정하면 slug를 복구한다 → 200", async () => {
+      await seedAdmin();
+      const cookie = await injectAuth(app);
+      const category = await seedCategory();
+      const post = await seedPost(category.id, {
+        title: "초기 제목",
+        slug: "-2",
+      });
+
+      const response = await app.inject({
+        method: "PATCH",
+        url: `/api/admin/posts/${post.id}`,
+        headers: { cookie },
+        payload: { title: "복구된 제목" },
+      });
+
+      expect(response.statusCode).toBe(200);
+      expect(response.json().post.slug).toBe("복구된-제목");
+    });
   });
 
   // ===== GET /api/admin/posts/:id =====

--- a/test/routes/posts.test.ts
+++ b/test/routes/posts.test.ts
@@ -224,6 +224,42 @@ describe("Post Routes", () => {
       expect(body.post.slug).toBe(String(body.post.id));
     });
 
+    it("id fallback slug가 이미 존재하면 숫자 suffix로 유니크하게 만든다 → 201", async () => {
+      await seedAdmin();
+      const cookie = await injectAuth(app);
+      const category = await seedCategory();
+
+      const existingNumericSlug = await app.inject({
+        method: "POST",
+        url: "/api/admin/posts",
+        headers: { cookie },
+        payload: {
+          title: "2",
+          contentMd: "# Existing numeric slug",
+          categoryId: category.id,
+        },
+      });
+
+      expect(existingNumericSlug.statusCode).toBe(201);
+      expect(existingNumericSlug.json().post.slug).toBe("2");
+
+      const response = await app.inject({
+        method: "POST",
+        url: "/api/admin/posts",
+        headers: { cookie },
+        payload: {
+          title: "!!!",
+          contentMd: "# Symbols only",
+          categoryId: category.id,
+        },
+      });
+
+      expect(response.statusCode).toBe(201);
+      const body = response.json();
+      expect(body.post.id).toBe(2);
+      expect(body.post.slug).toBe("2-2");
+    });
+
     it("status=published + publishedAt 없음 → publishedAt 자동 설정 → 201", async () => {
       await seedAdmin();
       const cookie = await injectAuth(app);

--- a/test/routes/posts.test.ts
+++ b/test/routes/posts.test.ts
@@ -157,7 +157,27 @@ describe("Post Routes", () => {
       expect(body.post.slug).toMatch(/hello-world-post/);
     });
 
-    it("중복 slug는 suffix로 유니크하게 생성된다 → 201", async () => {
+    it("한글 제목도 유니코드 slug로 생성한다 → 201", async () => {
+      await seedAdmin();
+      const cookie = await injectAuth(app);
+      const category = await seedCategory();
+
+      const response = await app.inject({
+        method: "POST",
+        url: "/api/admin/posts",
+        headers: { cookie },
+        payload: {
+          title: "한글 제목만 있는 글",
+          contentMd: "# 안녕하세요",
+          categoryId: category.id,
+        },
+      });
+
+      expect(response.statusCode).toBe(201);
+      expect(response.json().post.slug).toBe("한글-제목만-있는-글");
+    });
+
+    it("중복 slug는 생성된 post id를 fallback으로 사용한다 → 201", async () => {
       await seedAdmin();
       const cookie = await injectAuth(app);
       const category = await seedCategory();
@@ -177,9 +197,31 @@ describe("Post Routes", () => {
 
       expect(first.statusCode).toBe(201);
       expect(second.statusCode).toBe(201);
-      const slug1 = first.json().post.slug as string;
-      const slug2 = second.json().post.slug as string;
-      expect(slug1).not.toBe(slug2);
+      const firstBody = first.json();
+      const secondBody = second.json();
+      expect(firstBody.post.slug).toBe("duplicate-title");
+      expect(secondBody.post.slug).toBe(String(secondBody.post.id));
+    });
+
+    it("제목에서 slug를 만들 수 없으면 생성된 post id를 사용한다 → 201", async () => {
+      await seedAdmin();
+      const cookie = await injectAuth(app);
+      const category = await seedCategory();
+
+      const response = await app.inject({
+        method: "POST",
+        url: "/api/admin/posts",
+        headers: { cookie },
+        payload: {
+          title: "!!!",
+          contentMd: "# Symbols only",
+          categoryId: category.id,
+        },
+      });
+
+      expect(response.statusCode).toBe(201);
+      const body = response.json();
+      expect(body.post.slug).toBe(String(body.post.id));
     });
 
     it("status=published + publishedAt 없음 → publishedAt 자동 설정 → 201", async () => {
@@ -749,6 +791,26 @@ describe("Post Routes", () => {
 
       expect(response.statusCode).toBe(409);
       expect(response.json().message).toContain("Pinned post limit exceeded");
+    });
+
+    it("비정상 빈 slug 글을 수정하면 slug를 복구한다 → 200", async () => {
+      await seedAdmin();
+      const cookie = await injectAuth(app);
+      const category = await seedCategory();
+      const post = await seedPost(category.id, {
+        title: "초기 제목",
+        slug: "",
+      });
+
+      const response = await app.inject({
+        method: "PATCH",
+        url: `/api/admin/posts/${post.id}`,
+        headers: { cookie },
+        payload: { title: "복구된 제목" },
+      });
+
+      expect(response.statusCode).toBe(200);
+      expect(response.json().post.slug).toBe("복구된-제목");
     });
   });
 


### PR DESCRIPTION
## Summary

Closes #92

Post slugs now preserve unicode title text when possible, and fall back to the numeric post id when the generated slug is blank or already taken.

## Changes

| File | Change |
|------|--------|
| `src/shared/slug.ts` | Updated slug generation to preserve unicode letters and numbers while normalizing separators. |
| `src/routes/posts/post.service.ts` | Changed post creation to resolve slugs after insert so duplicate/blank cases can fall back to `post.id`, and repair invalid stored slugs on edit. |
| `drizzle/0009_fix_invalid_post_slugs.sql` | Added a migration to repair existing invalid stored slugs to the numeric post id. |
| `test/routes/posts.test.ts` | Added regression coverage for unicode slugs, id fallback, and slug repair. |
