### PR TITLE
fix: parse includeDeleted query param as strict boolean

### DIFF
--- a/src/routes/posts/post.schema.ts
+++ b/src/routes/posts/post.schema.ts
@@ -14,6 +14,14 @@ const isAllowedThumbnailUrl = (value: string): boolean => {
   }
 };
 
+// z.coerce.boolean()은 Boolean(v)이라 "false" 같은 문자열도 true가 된다.
+// 쿼리스트링은 항상 문자열이므로 명시적으로 파싱해야 한다.
+const BooleanQueryParam = z
+  .union([z.boolean(), z.enum(["true", "false", "1", "0"])])
+  .transform((value) =>
+    typeof value === "boolean" ? value : value === "true" || value === "1",
+  );
+
 const ThumbnailUrlInputSchema = z
   .string()
   .trim()
@@ -56,7 +64,7 @@ export const PostListQuerySchema = z.object({
     .default("published_at")
     .describe("정렬 기준 필드"),
   order: z.enum(["asc", "desc"]).optional().default("desc").describe("정렬 방향"),
-  includeDeleted: z.coerce.boolean().optional().default(false).describe("삭제된 게시글 포함 여부"),
+  includeDeleted: BooleanQueryParam.optional().default(false).describe("삭제된 게시글 포함 여부"),
 });
 
 export const AdminPostListQuerySchema = z.object({
@@ -73,7 +81,7 @@ export const AdminPostListQuerySchema = z.object({
     .default("created_at")
     .describe("정렬 기준 필드"),
   order: z.enum(["asc", "desc"]).optional().default("desc").describe("정렬 방향"),
-  includeDeleted: z.coerce.boolean().optional().default(false).describe("삭제된 게시글 포함 여부"),
+  includeDeleted: BooleanQueryParam.optional().default(false).describe("삭제된 게시글 포함 여부"),
 });
 
 /**

--- a/test/routes/posts.test.ts
+++ b/test/routes/posts.test.ts
@@ -1082,6 +1082,34 @@ describe("Post Routes", () => {
       expect(withDeleted.json().data).toHaveLength(1);
     });
 
+    it("includeDeleted=false 쿼리스트링 → 삭제된 글 제외 (회귀 방지)", async () => {
+      // z.coerce.boolean() 은 Boolean("false") === true 로 강제변환되어
+      // 이 쿼리를 정확히 오분해하는 버그가 있었다. 문자열 "false" 가
+      // deletedAt IS NULL 필터를 유지하는지 명시적으로 확인한다.
+      await seedAdmin();
+      const cookie = await injectAuth(app);
+      const category = await seedCategory();
+
+      const activePost = await seedPost(category.id);
+      const deletedPost = await seedPost(category.id);
+      await app.inject({
+        method: "DELETE",
+        url: `/api/admin/posts/${deletedPost.id}`,
+        headers: { cookie },
+      });
+
+      const response = await app.inject({
+        method: "GET",
+        url: "/api/admin/posts?includeDeleted=false",
+        headers: { cookie },
+      });
+
+      expect(response.statusCode).toBe(200);
+      const data = response.json().data as { id: number }[];
+      expect(data).toHaveLength(1);
+      expect(data[0].id).toBe(activePost.id);
+    });
+
     it("페이지네이션 — limit=2, 총 3개 → meta.totalCount=3", async () => {
       await seedAdmin();
       const cookie = await injectAuth(app);


### PR DESCRIPTION
## Problem

Admin post list의 `active` 탭이 `?includeDeleted=false`를 전송해도 soft-delete 된 글이 여전히 목록에 노출됩니다.

## Root cause

`post.schema.ts` 의 `includeDeleted` 필드가 `z.coerce.boolean()` 로 정의되어 있습니다. Zod 의 `coerce.boolean()` 은 내부적으로 `Boolean(value)` 를 호출하므로, 비어있지 않은 어떤 문자열이든 `true` 로 변환됩니다 - 즉 쿼리스트링 `"false"` 도 `true` 가 됩니다.

그 결과 `post.service.ts:452` 의 `isNull(postTable.deletedAt)` 필터가 스킵되어 삭제된 글이 active 탭에 남게 됩니다.

## Fix

`BooleanQueryParam` 헬퍼를 추가해 `true`/`false`/`1`/`0` 문자열 (및 실제 boolean) 만 허용하도록 명시적으로 파싱합니다. `PostListQuerySchema` 와 `AdminPostListQuerySchema` 양쪽에 적용했습니다.

## Verification

- 로컬 재현 스크립트로 수정 전후 동작 확인
  - 수정 전: `z.coerce.boolean()` + `{ includeDeleted: "false" }` → `true` (버그)
  - 수정 후: 7개 케이스 (default / "true" / "false" / true / false / "0" / "1") 모두 PASS
- `pnpm compile:types` (tsc --noEmit) 통과

DB 가 필요한 vitest suite 는 본 환경에서 `.env.test` 접근 제한으로 실행하지 못했습니다.