### PR TITLE
fix(entrypoint): export APP_VERSION from package.json at runtime

### DIFF
--- a/scripts/entrypoint.sh
+++ b/scripts/entrypoint.sh
@@ -8,4 +8,5 @@ echo "[Entrypoint] Running database migrations..."
 node ./build/src/scripts/migrate.js
 
 echo "[Entrypoint] Starting server..."
+export APP_VERSION="$(node -p "require('./package.json').version")"
 exec node ./build/src/server.js


### PR DESCRIPTION
## Problem

`/api/health/live`, `/api/health/ready`, `/api/health` 응답의 `version` 필드가 `"unknown"`으로 나옴.

`getAppVersion()`은 `process.env.APP_VERSION || process.env.npm_package_version`을 참조하는데, 컨테이너는 `entrypoint.sh`에서 `node ./build/src/server.js`를 직접 호출하므로 둘 다 주입되지 않음.

## Fix

`entrypoint.sh`에서 서버 실행 직전에 이미지에 이미 존재하는 `package.json`의 version을 읽어 `APP_VERSION`으로 export.

## Verification

머지 + 새 release (v1.0.1) 생성 후 OCI 재배포 → \`curl https://api.pyosh.com/api/health/live\` 응답의 \`version\` 필드가 \`"1.0.1"\`로 나와야 함.