### PR TITLE
refactor: remove server api prefix (#96)

### DIFF
--- a/api-spec.md
+++ b/api-spec.md
@@ -2,7 +2,7 @@
 
 ## Admin Posts
 
-### GET `/api/admin/posts`
+### GET `/admin/posts`
 
 Auth: `requireAdmin`
 
@@ -32,7 +32,7 @@ Response `200`:
 
 ## Admin Comments
 
-### PUT `/api/admin/comments/:id/hide`
+### PUT `/admin/comments/:id/hide`
 
 Auth: `requireAdmin`
 
@@ -45,7 +45,7 @@ Response `200`:
 { "success": true }
 ```
 
-### PUT `/api/admin/comments/:id/restore`
+### PUT `/admin/comments/:id/restore`
 
 Auth: `requireAdmin`
 
@@ -58,7 +58,7 @@ Response `200`:
 { "success": true }
 ```
 
-### DELETE `/api/admin/comments/bulk`
+### DELETE `/admin/comments/bulk`
 
 Auth: `requireAdmin`
 
@@ -78,7 +78,7 @@ Request Body:
 
 ## Guestbook
 
-### POST `/api/guestbook`
+### POST `/guestbook`
 
 Auth: `optionalAuth`
 
@@ -111,7 +111,7 @@ Response `201`:
 { "data": GuestbookEntryDetail }
 ```
 
-### DELETE `/api/guestbook/:id`
+### DELETE `/guestbook/:id`
 
 Auth: `optionalAuth`
 

--- a/src/app.ts
+++ b/src/app.ts
@@ -145,6 +145,11 @@ export async function buildApp(): Promise<FastifyInstance> {
     });
   });
 
+  // Lightweight liveness check for load balancers and uptime probes.
+  fastify.get("/health", async () => {
+    return { status: "ok", timestamp: new Date().toISOString() };
+  });
+
   fastify.get("/health/live", async () => {
     return {
       status: "ok",
@@ -172,7 +177,7 @@ export async function buildApp(): Promise<FastifyInstance> {
     };
   });
 
-  fastify.get("/health", async (_, reply) => {
+  fastify.get("/health/status", async (_, reply) => {
     const database = await getDatabaseHealth(fastify);
     const health = getHealthStatus("health", database);
 

--- a/src/app.ts
+++ b/src/app.ts
@@ -145,12 +145,7 @@ export async function buildApp(): Promise<FastifyInstance> {
     });
   });
 
-  // Health check 엔드포인트
-  fastify.get("/health", async () => {
-    return { status: "ok", timestamp: new Date().toISOString() };
-  });
-
-  fastify.get("/api/health/live", async () => {
+  fastify.get("/health/live", async () => {
     return {
       status: "ok",
       timestamp: new Date().toISOString(),
@@ -159,7 +154,7 @@ export async function buildApp(): Promise<FastifyInstance> {
     };
   });
 
-  fastify.get("/api/health/ready", async (_, reply) => {
+  fastify.get("/health/ready", async (_, reply) => {
     const database = await getDatabaseHealth(fastify);
     const health = getHealthStatus("ready", database);
 
@@ -177,7 +172,7 @@ export async function buildApp(): Promise<FastifyInstance> {
     };
   });
 
-  fastify.get("/api/health", async (_, reply) => {
+  fastify.get("/health", async (_, reply) => {
     const database = await getDatabaseHealth(fastify);
     const health = getHealthStatus("health", database);
 
@@ -213,41 +208,41 @@ export async function buildApp(): Promise<FastifyInstance> {
 
   // 라우트 등록
   await fastify.register(createAuthRoute(adminService), {
-    prefix: "/api/auth",
+    prefix: "/auth",
   });
   await fastify.register(createCategoryRoute(categoryService, adminService), {
-    prefix: "/api/categories",
+    prefix: "/categories",
   });
   await fastify.register(createAssetRoute(assetService, adminService), {
-    prefix: "/api/assets",
+    prefix: "/assets",
   });
   await fastify.register(createPostRoute(postService), {
-    prefix: "/api/posts",
+    prefix: "/posts",
   });
   await fastify.register(createTagRoute(tagService), {
-    prefix: "/api/tags",
+    prefix: "/tags",
   });
   // Comment routes (public)
   await fastify.register(createCommentRoute(commentService), {
-    prefix: "/api",
+    prefix: "",
   });
 
   // Guestbook routes (public)
   await fastify.register(
     createGuestbookRoute(guestbookService, settingsService),
     {
-      prefix: "/api",
+      prefix: "",
     },
   );
 
   // Settings routes (public)
   await fastify.register(createSettingsRoute(settingsService), {
-    prefix: "/api/settings",
+    prefix: "/settings",
   });
 
   // Stats routes (public)
   await fastify.register(createStatsRoute(statsService), {
-    prefix: "/api/stats",
+    prefix: "/stats",
   });
 
   // Admin routes: CSRF 보호 (GET 제외) 일괄 적용
@@ -280,13 +275,13 @@ export async function buildApp(): Promise<FastifyInstance> {
         prefix: "/stats",
       });
     },
-    { prefix: "/api/admin" },
+    { prefix: "/admin" },
   );
   await fastify.register(createSeoRoute());
 
   // User routes (OAuth 인증 필수)
   await fastify.register(createUserRoute(userService), {
-    prefix: "/api/user",
+    prefix: "/user",
   });
 
   return fastify;

--- a/src/plugins/passport.ts
+++ b/src/plugins/passport.ts
@@ -38,7 +38,7 @@ const passportPlugin: FastifyPluginAsync = async (fastify) => {
         {
           clientID: env.GOOGLE_CLIENT_ID,
           clientSecret: env.GOOGLE_CLIENT_SECRET,
-          callbackURL: "/api/auth/google/callback",
+          callbackURL: "/auth/google/callback",
         },
         async (_accessToken, _refreshToken, profile, done) => {
           try {
@@ -103,7 +103,7 @@ const passportPlugin: FastifyPluginAsync = async (fastify) => {
         {
           clientID: env.GITHUB_CLIENT_ID,
           clientSecret: env.GITHUB_CLIENT_SECRET,
-          callbackURL: "/api/auth/github/callback",
+          callbackURL: "/auth/github/callback",
         },
         async (_accessToken, _refreshToken, profile, done) => {
           try {

--- a/src/routes/assets/asset.route.ts
+++ b/src/routes/assets/asset.route.ts
@@ -27,7 +27,7 @@ export function createAssetRoute(
   const assetRoute: FastifyPluginAsync = async (fastify: FastifyInstance) => {
     const typedFastify = fastify.withTypeProvider<ZodTypeProvider>();
 
-    // POST /api/assets/upload - 파일 업로드 (Admin)
+    // POST /assets/upload - 파일 업로드 (Admin)
     typedFastify.post(
       "/upload",
       {
@@ -44,7 +44,7 @@ export function createAssetRoute(
             "- 최대 파일 크기: 10MB\n" +
             "- 최대 동시 업로드: 5개\n" +
             "- 허용 MIME 타입: `image/jpeg`, `image/png`, `image/gif`, `image/webp`, `image/svg+xml`\n\n" +
-            "**CSRF 토큰 필요**: `GET /api/auth/csrf-token`으로 토큰을 발급받아 " +
+            "**CSRF 토큰 필요**: `GET /auth/csrf-token`으로 토큰을 발급받아 " +
             "`x-csrf-token` 헤더에 포함해야 합니다.",
           security: [{ cookieAuth: [] }],
           response: {
@@ -77,7 +77,7 @@ export function createAssetRoute(
       },
     );
 
-    // GET /api/assets - Asset 목록 조회 (Admin)
+    // GET /assets - Asset 목록 조회 (Admin)
     typedFastify.get(
       "/",
       {
@@ -103,7 +103,7 @@ export function createAssetRoute(
       },
     );
 
-    // GET /api/assets/:id - Asset 메타데이터 조회 (Public, 선택)
+    // GET /assets/:id - Asset 메타데이터 조회 (Public, 선택)
     typedFastify.get(
       "/:id",
       {
@@ -126,7 +126,7 @@ export function createAssetRoute(
       },
     );
 
-    // DELETE /api/assets/bulk - Asset 벌크 삭제 (Admin)
+    // DELETE /assets/bulk - Asset 벌크 삭제 (Admin)
     typedFastify.delete(
       "/bulk",
       {
@@ -137,7 +137,7 @@ export function createAssetRoute(
           summary: "Bulk delete assets",
           description:
             "여러 Asset을 한 번에 삭제합니다. Admin 권한이 필요합니다. DB는 단일 트랜잭션, 파일 삭제는 best-effort.\n\n" +
-            "**CSRF 토큰 필요**: `GET /api/auth/csrf-token`으로 토큰을 발급받아 " +
+            "**CSRF 토큰 필요**: `GET /auth/csrf-token`으로 토큰을 발급받아 " +
             "`x-csrf-token` 헤더에 포함해야 합니다.",
           security: [{ cookieAuth: [] }],
           body: bulkDeleteAssetsBodySchema,
@@ -156,7 +156,7 @@ export function createAssetRoute(
       },
     );
 
-    // DELETE /api/assets/:id - Asset 삭제 (Admin)
+    // DELETE /assets/:id - Asset 삭제 (Admin)
     typedFastify.delete(
       "/:id",
       {
@@ -167,7 +167,7 @@ export function createAssetRoute(
           summary: "Delete asset",
           description:
             "Asset을 삭제합니다. Admin 권한이 필요합니다. DB 레코드와 실제 파일 모두 삭제됩니다.\n\n" +
-            "**CSRF 토큰 필요**: `GET /api/auth/csrf-token`으로 토큰을 발급받아 " +
+            "**CSRF 토큰 필요**: `GET /auth/csrf-token`으로 토큰을 발급받아 " +
             "`x-csrf-token` 헤더에 포함해야 합니다.",
           security: [{ cookieAuth: [] }],
           params: assetIdParamSchema,

--- a/src/routes/auth/auth.route.ts
+++ b/src/routes/auth/auth.route.ts
@@ -171,7 +171,7 @@ export function createAuthRoute(
           summary: "Admin logout",
           description:
             "관리자 세션을 종료합니다.\n\n" +
-            "**CSRF 토큰 필요**: `GET /api/auth/csrf-token`으로 토큰을 발급받아 " +
+            "**CSRF 토큰 필요**: `GET /auth/csrf-token`으로 토큰을 발급받아 " +
             "`x-csrf-token` 헤더에 포함해야 합니다.",
           security: [{ cookieAuth: [] }],
           response: {

--- a/src/routes/categories/category.route.ts
+++ b/src/routes/categories/category.route.ts
@@ -44,7 +44,7 @@ export function createCategoryRoute(
   ) => {
     const typedFastify = fastify.withTypeProvider<ZodTypeProvider>();
 
-    // GET /api/categories - 전체 카테고리 트리 조회 (Public)
+    // GET /categories - 전체 카테고리 트리 조회 (Public)
     typedFastify.get(
       "/",
       {
@@ -79,7 +79,7 @@ export function createCategoryRoute(
       },
     );
 
-    // POST /api/categories - 카테고리 생성 (Admin)
+    // POST /categories - 카테고리 생성 (Admin)
     typedFastify.post(
       "/",
       {
@@ -90,7 +90,7 @@ export function createCategoryRoute(
           summary: "Create category",
           description:
             "새 카테고리를 생성합니다. Admin 권한이 필요합니다.\n\n" +
-            "**CSRF 토큰 필요**: `GET /api/auth/csrf-token`으로 토큰을 발급받아 " +
+            "**CSRF 토큰 필요**: `GET /auth/csrf-token`으로 토큰을 발급받아 " +
             "`x-csrf-token` 헤더에 포함해야 합니다.",
           security: [{ cookieAuth: [] }],
           body: CategoryCreateBodySchema,
@@ -119,7 +119,7 @@ export function createCategoryRoute(
       },
     );
 
-    // PATCH /api/categories/tree - 카테고리 트리 배치 변경 (Admin)
+    // PATCH /categories/tree - 카테고리 트리 배치 변경 (Admin)
     // 반드시 /:id 앞에 등록해야 정적 경로 우선 매칭 보장
     typedFastify.patch(
       "/tree",
@@ -131,7 +131,7 @@ export function createCategoryRoute(
           summary: "Batch update category tree",
           description:
             "여러 카테고리의 parentId와 sortOrder를 단일 트랜잭션으로 변경합니다. Admin 권한이 필요합니다.\n\n" +
-            "**CSRF 토큰 필요**: `GET /api/auth/csrf-token`으로 토큰을 발급받아 " +
+            "**CSRF 토큰 필요**: `GET /auth/csrf-token`으로 토큰을 발급받아 " +
             "`x-csrf-token` 헤더에 포함해야 합니다.",
           security: [{ cookieAuth: [] }],
           body: CategoryTreeUpdateBodySchema,
@@ -150,7 +150,7 @@ export function createCategoryRoute(
       },
     );
 
-    // PATCH /api/categories/:id - 카테고리 수정 (Admin)
+    // PATCH /categories/:id - 카테고리 수정 (Admin)
     typedFastify.patch(
       "/:id",
       {
@@ -161,7 +161,7 @@ export function createCategoryRoute(
           summary: "Update category",
           description:
             "카테고리 정보를 수정합니다. Admin 권한이 필요합니다.\n\n" +
-            "**CSRF 토큰 필요**: `GET /api/auth/csrf-token`으로 토큰을 발급받아 " +
+            "**CSRF 토큰 필요**: `GET /auth/csrf-token`으로 토큰을 발급받아 " +
             "`x-csrf-token` 헤더에 포함해야 합니다.",
           security: [{ cookieAuth: [] }],
           params: CategoryIdParamSchema,
@@ -196,7 +196,7 @@ export function createCategoryRoute(
       },
     );
 
-    // DELETE /api/categories/:id - 카테고리 삭제 (Admin)
+    // DELETE /categories/:id - 카테고리 삭제 (Admin)
     typedFastify.delete(
       "/:id",
       {
@@ -207,7 +207,7 @@ export function createCategoryRoute(
           summary: "Delete category",
           description:
             "카테고리를 삭제합니다. action=move면 게시글을 지정 카테고리로 이동, action=trash면 게시글을 휴지통으로 이동합니다. 하위 카테고리가 있으면 삭제할 수 없습니다. Admin 권한이 필요합니다.\n\n" +
-            "**CSRF 토큰 필요**: `GET /api/auth/csrf-token`으로 토큰을 발급받아 " +
+            "**CSRF 토큰 필요**: `GET /auth/csrf-token`으로 토큰을 발급받아 " +
             "`x-csrf-token` 헤더에 포함해야 합니다.",
           security: [{ cookieAuth: [] }],
           params: CategoryIdParamSchema,

--- a/src/routes/comments/comment.route.ts
+++ b/src/routes/comments/comment.route.ts
@@ -36,7 +36,7 @@ export function createCommentRoute(
   const commentRoute: FastifyPluginAsync = async (fastify: FastifyInstance) => {
     const typedFastify = fastify.withTypeProvider<ZodTypeProvider>();
 
-    // GET /api/posts/:postId/comments - 댓글 목록 조회 (Public, 페이지네이션)
+    // GET /posts/:postId/comments - 댓글 목록 조회 (Public, 페이지네이션)
     typedFastify.get(
       "/posts/:postId/comments",
       {
@@ -73,7 +73,7 @@ export function createCommentRoute(
       },
     );
 
-    // POST /api/posts/:postId/comments - 댓글 작성 (OAuth 또는 Guest)
+    // POST /posts/:postId/comments - 댓글 작성 (OAuth 또는 Guest)
     typedFastify.post(
       "/posts/:postId/comments",
       {
@@ -89,7 +89,7 @@ export function createCommentRoute(
           summary: "댓글 작성",
           description:
             "OAuth 로그인 사용자 또는 게스트가 댓글을 작성합니다. 게스트는 이름과 비밀번호를 전달해야 하며, 비밀 댓글이면 복원 토큰이 함께 발급됩니다.\n\n" +
-            "**CSRF 토큰 필요**: `GET /api/auth/csrf-token`으로 토큰을 발급받아 " +
+            "**CSRF 토큰 필요**: `GET /auth/csrf-token`으로 토큰을 발급받아 " +
             "`x-csrf-token` 헤더에 포함해야 합니다.\n\n" +
             "**Rate limit**: 10회/분",
           params: PostIdParamSchema,
@@ -193,7 +193,7 @@ export function createCommentRoute(
       },
     );
 
-    // DELETE /api/comments/:id - 댓글 삭제 (본인 또는 게스트 비밀번호)
+    // DELETE /comments/:id - 댓글 삭제 (본인 또는 게스트 비밀번호)
     typedFastify.delete(
       "/comments/:id",
       {
@@ -203,7 +203,7 @@ export function createCommentRoute(
           summary: "댓글 삭제",
           description:
             "본인이 작성한 댓글을 삭제합니다. 게스트 댓글의 경우 비밀번호를 함께 전달해야 합니다.\n\n" +
-            "**CSRF 토큰 필요**: `GET /api/auth/csrf-token`으로 토큰을 발급받아 " +
+            "**CSRF 토큰 필요**: `GET /auth/csrf-token`으로 토큰을 발급받아 " +
             "`x-csrf-token` 헤더에 포함해야 합니다.",
           params: CommentIdParamSchema,
           body: DeleteCommentGuestBodySchema.nullish(),
@@ -252,7 +252,7 @@ export function createAdminCommentRoute(
   ) => {
     const typedFastify = fastify.withTypeProvider<ZodTypeProvider>();
 
-    // GET /api/admin/comments - 관리자 댓글 목록 조회
+    // GET /admin/comments - 관리자 댓글 목록 조회
     typedFastify.get(
       "/comments",
       {
@@ -279,7 +279,7 @@ export function createAdminCommentRoute(
       },
     );
 
-    // GET /api/admin/comments/:id/thread - 스레드 조회 (부모 + 모든 답글)
+    // GET /admin/comments/:id/thread - 스레드 조회 (부모 + 모든 답글)
     typedFastify.get(
       "/comments/:id/thread",
       {
@@ -305,7 +305,7 @@ export function createAdminCommentRoute(
       },
     );
 
-    // PUT /api/admin/comments/:id/hide - 댓글 숨김 (active → hidden)
+    // PUT /admin/comments/:id/hide - 댓글 숨김 (active → hidden)
     typedFastify.put(
       "/comments/:id/hide",
       {
@@ -315,7 +315,7 @@ export function createAdminCommentRoute(
           summary: "관리자 댓글 숨김",
           description:
             "active 상태 댓글을 hidden 상태로 전환합니다. deleted 또는 hidden 상태 댓글은 400을 반환합니다.\n\n" +
-            "**CSRF 토큰 필요**: `GET /api/auth/csrf-token`으로 토큰을 발급받아 " +
+            "**CSRF 토큰 필요**: `GET /auth/csrf-token`으로 토큰을 발급받아 " +
             "`x-csrf-token` 헤더에 포함해야 합니다.",
           security: [{ cookieAuth: [] }],
           params: CommentIdParamSchema,
@@ -336,7 +336,7 @@ export function createAdminCommentRoute(
       },
     );
 
-    // PUT /api/admin/comments/:id/restore - 댓글 복원 (deleted | hidden → active)
+    // PUT /admin/comments/:id/restore - 댓글 복원 (deleted | hidden → active)
     typedFastify.put(
       "/comments/:id/restore",
       {
@@ -345,7 +345,7 @@ export function createAdminCommentRoute(
           summary: "관리자 댓글 복원",
           description:
             "deleted 또는 hidden 상태 댓글을 active 상태로 복원합니다. active 상태 댓글은 400을 반환합니다.\n\n" +
-            "**CSRF 토큰 필요**: `GET /api/auth/csrf-token`으로 토큰을 발급받아 " +
+            "**CSRF 토큰 필요**: `GET /auth/csrf-token`으로 토큰을 발급받아 " +
             "`x-csrf-token` 헤더에 포함해야 합니다.",
           security: [{ cookieAuth: [] }],
           params: CommentIdParamSchema,
@@ -366,7 +366,7 @@ export function createAdminCommentRoute(
       },
     );
 
-    // DELETE /api/admin/comments/bulk - 벌크 삭제/복원
+    // DELETE /admin/comments/bulk - 벌크 삭제/복원
     // Static path '/bulk' takes priority over '/:id' in find-my-way; ordering is for readability only.
     typedFastify.delete(
       "/comments/bulk",
@@ -377,7 +377,7 @@ export function createAdminCommentRoute(
           summary: "관리자 댓글 벌크 작업",
           description:
             "여러 댓글을 한 번에 숨김, 복원, 소프트 삭제, 또는 하드 삭제합니다. hide는 active 상태만 hidden으로 전환하고, restore는 deleted 또는 hidden 상태를 active로 복원합니다.\n\n" +
-            "**CSRF 토큰 필요**: `GET /api/auth/csrf-token`으로 토큰을 발급받아 " +
+            "**CSRF 토큰 필요**: `GET /auth/csrf-token`으로 토큰을 발급받아 " +
             "`x-csrf-token` 헤더에 포함해야 합니다.",
           security: [{ cookieAuth: [] }],
           body: AdminCommentBulkBodySchema,
@@ -397,7 +397,7 @@ export function createAdminCommentRoute(
       },
     );
 
-    // DELETE /api/admin/comments/:id - 관리자 댓글 삭제 (soft/hard)
+    // DELETE /admin/comments/:id - 관리자 댓글 삭제 (soft/hard)
     typedFastify.delete(
       "/comments/:id",
       {
@@ -406,7 +406,7 @@ export function createAdminCommentRoute(
           summary: "관리자 댓글 삭제",
           description:
             "관리자가 댓글을 삭제합니다. ?action=soft_delete(기본) 또는 ?action=hard_delete.\n\n" +
-            "**CSRF 토큰 필요**: `GET /api/auth/csrf-token`으로 토큰을 발급받아 " +
+            "**CSRF 토큰 필요**: `GET /auth/csrf-token`으로 토큰을 발급받아 " +
             "`x-csrf-token` 헤더에 포함해야 합니다.",
           security: [{ cookieAuth: [] }],
           params: CommentIdParamSchema,

--- a/src/routes/guestbook/guestbook.route.ts
+++ b/src/routes/guestbook/guestbook.route.ts
@@ -37,7 +37,7 @@ export function createGuestbookRoute(
   ) => {
     const typedFastify = fastify.withTypeProvider<ZodTypeProvider>();
 
-    // GET /api/guestbook - 방명록 목록 조회 (Public, 페이지네이션)
+    // GET /guestbook - 방명록 목록 조회 (Public, 페이지네이션)
     typedFastify.get(
       "/guestbook",
       {
@@ -72,7 +72,7 @@ export function createGuestbookRoute(
       },
     );
 
-    // POST /api/guestbook - 방명록 작성 (OAuth 또는 Guest)
+    // POST /guestbook - 방명록 작성 (OAuth 또는 Guest)
     typedFastify.post(
       "/guestbook",
       {
@@ -88,7 +88,7 @@ export function createGuestbookRoute(
           summary: "방명록 작성",
           description:
             "OAuth 로그인 사용자 또는 게스트가 방명록을 작성합니다. 게스트는 이름, 이메일, 비밀번호를 함께 전달해야 합니다.\n\n" +
-            "**CSRF 토큰 필요**: `GET /api/auth/csrf-token`으로 토큰을 발급받아 " +
+            "**CSRF 토큰 필요**: `GET /auth/csrf-token`으로 토큰을 발급받아 " +
             "`x-csrf-token` 헤더에 포함해야 합니다.\n\n" +
             "**Rate limit**: 10회/분",
           body: z.union([
@@ -157,7 +157,7 @@ export function createGuestbookRoute(
       },
     );
 
-    // DELETE /api/guestbook/:id - 방명록 삭제 (본인 또는 게스트 비밀번호)
+    // DELETE /guestbook/:id - 방명록 삭제 (본인 또는 게스트 비밀번호)
     typedFastify.delete(
       "/guestbook/:id",
       {
@@ -167,7 +167,7 @@ export function createGuestbookRoute(
           summary: "방명록 삭제",
           description:
             "본인이 작성한 방명록을 삭제합니다. 게스트 방명록의 경우 비밀번호를 함께 전달해야 합니다.\n\n" +
-            "**CSRF 토큰 필요**: `GET /api/auth/csrf-token`으로 토큰을 발급받아 " +
+            "**CSRF 토큰 필요**: `GET /auth/csrf-token`으로 토큰을 발급받아 " +
             "`x-csrf-token` 헤더에 포함해야 합니다.",
           params: GuestbookIdParamSchema,
           body: DeleteGuestbookGuestBodySchema.nullish(),
@@ -217,7 +217,7 @@ export function createAdminGuestbookRoute(
   ) => {
     const typedFastify = fastify.withTypeProvider<ZodTypeProvider>();
 
-    // GET /api/admin/guestbook - 관리자 방명록 목록 조회
+    // GET /admin/guestbook - 관리자 방명록 목록 조회
     typedFastify.get(
       "/guestbook",
       {
@@ -243,7 +243,7 @@ export function createAdminGuestbookRoute(
       },
     );
 
-    // DELETE /api/admin/guestbook/bulk - 관리자 방명록 벌크 삭제 (비가역: soft_delete | hard_delete)
+    // DELETE /admin/guestbook/bulk - 관리자 방명록 벌크 삭제 (비가역: soft_delete | hard_delete)
     typedFastify.delete(
       "/guestbook/bulk",
       {
@@ -251,8 +251,8 @@ export function createAdminGuestbookRoute(
           tags: ["admin", "guestbook"],
           summary: "관리자 방명록 벌크 삭제",
           description:
-            "방명록을 비가역적으로 삭제합니다. hide/restore는 PATCH /api/admin/guestbook/bulk를 사용하세요.\n\n" +
-            "**CSRF 토큰 필요**: `GET /api/auth/csrf-token`으로 토큰을 발급받아 " +
+            "방명록을 비가역적으로 삭제합니다. hide/restore는 PATCH /admin/guestbook/bulk를 사용하세요.\n\n" +
+            "**CSRF 토큰 필요**: `GET /auth/csrf-token`으로 토큰을 발급받아 " +
             "`x-csrf-token` 헤더에 포함해야 합니다.",
           security: [{ cookieAuth: [] }],
           body: AdminGuestbookBulkDeleteBodySchema,
@@ -271,7 +271,7 @@ export function createAdminGuestbookRoute(
       },
     );
 
-    // PATCH /api/admin/guestbook/bulk - 관리자 방명록 벌크 상태 변경 (가역: hide | restore)
+    // PATCH /admin/guestbook/bulk - 관리자 방명록 벌크 상태 변경 (가역: hide | restore)
     typedFastify.patch(
       "/guestbook/bulk",
       {
@@ -280,7 +280,7 @@ export function createAdminGuestbookRoute(
           summary: "관리자 방명록 벌크 상태 변경",
           description:
             "방명록 상태를 가역적으로 변경합니다. hide: 공개 목록에서 숨김, restore: active 복원.\n\n" +
-            "**CSRF 토큰 필요**: `GET /api/auth/csrf-token`으로 토큰을 발급받아 " +
+            "**CSRF 토큰 필요**: `GET /auth/csrf-token`으로 토큰을 발급받아 " +
             "`x-csrf-token` 헤더에 포함해야 합니다.",
           security: [{ cookieAuth: [] }],
           body: AdminGuestbookBulkPatchBodySchema,
@@ -299,7 +299,7 @@ export function createAdminGuestbookRoute(
       },
     );
 
-    // PATCH /api/admin/guestbook/:id - 관리자 방명록 상태 변경 (가역: hide | restore)
+    // PATCH /admin/guestbook/:id - 관리자 방명록 상태 변경 (가역: hide | restore)
     typedFastify.patch(
       "/guestbook/:id",
       {
@@ -308,7 +308,7 @@ export function createAdminGuestbookRoute(
           summary: "관리자 방명록 상태 변경",
           description:
             "방명록 상태를 가역적으로 변경합니다. hide: active→hidden, restore: hidden→active. 상태 조건 불일치 시 204를 반환하며 no-op 처리됩니다.\n\n" +
-            "**CSRF 토큰 필요**: `GET /api/auth/csrf-token`으로 토큰을 발급받아 " +
+            "**CSRF 토큰 필요**: `GET /auth/csrf-token`으로 토큰을 발급받아 " +
             "`x-csrf-token` 헤더에 포함해야 합니다.",
           security: [{ cookieAuth: [] }],
           params: GuestbookIdParamSchema,
@@ -329,7 +329,7 @@ export function createAdminGuestbookRoute(
       },
     );
 
-    // DELETE /api/admin/guestbook/:id - 관리자 방명록 삭제 (비가역: soft_delete | hard_delete)
+    // DELETE /admin/guestbook/:id - 관리자 방명록 삭제 (비가역: soft_delete | hard_delete)
     typedFastify.delete(
       "/guestbook/:id",
       {
@@ -338,7 +338,7 @@ export function createAdminGuestbookRoute(
           summary: "관리자 방명록 삭제",
           description:
             "방명록을 비가역적으로 삭제합니다. action 쿼리로 soft_delete | hard_delete를 지정합니다.\n\n" +
-            "**CSRF 토큰 필요**: `GET /api/auth/csrf-token`으로 토큰을 발급받아 " +
+            "**CSRF 토큰 필요**: `GET /auth/csrf-token`으로 토큰을 발급받아 " +
             "`x-csrf-token` 헤더에 포함해야 합니다.",
           security: [{ cookieAuth: [] }],
           params: GuestbookIdParamSchema,

--- a/src/routes/guestbook/guestbook.schema.ts
+++ b/src/routes/guestbook/guestbook.schema.ts
@@ -128,7 +128,7 @@ export const AdminGuestbookListQuerySchema = z.object({
 
 /**
  * 관리자 방명록 단건 삭제 쿼리 스키마 (DELETE - 비가역적 액션만)
- * hide는 PATCH /api/admin/guestbook/:id를 사용
+ * hide는 PATCH /admin/guestbook/:id를 사용
  */
 export const AdminGuestbookDeleteQuerySchema = z.object({
   action: z.enum(["soft_delete", "hard_delete"]).describe("삭제 방식 (soft_delete: 복원 가능, hard_delete: 영구 삭제)"),
@@ -147,7 +147,7 @@ export const AdminGuestbookPatchQuerySchema = z.object({
  * 관리자 방명록 벌크 삭제 요청 스키마 (DELETE - 비가역적 액션만)
  * - soft_delete: status=deleted, deletedAt 설정
  * - hard_delete: DB에서 완전 삭제
- * hide/restore는 PATCH /api/admin/guestbook/bulk를 사용
+ * hide/restore는 PATCH /admin/guestbook/bulk를 사용
  * 최대 100개까지 처리 가능
  */
 export const AdminGuestbookBulkDeleteBodySchema = z.object({

--- a/src/routes/posts/post.route.ts
+++ b/src/routes/posts/post.route.ts
@@ -27,7 +27,7 @@ export function createPostRoute(postService: PostService): FastifyPluginAsync {
   const postRoute: FastifyPluginAsync = async (fastify: FastifyInstance) => {
     const typedFastify = fastify.withTypeProvider<ZodTypeProvider>();
 
-    // GET /api/posts - 게시글 목록 조회 (Public)
+    // GET /posts - 게시글 목록 조회 (Public)
     typedFastify.get(
       "/",
       {
@@ -71,7 +71,7 @@ export function createPostRoute(postService: PostService): FastifyPluginAsync {
       },
     );
 
-    // GET /api/posts/slugs - 발행된 글 slug 목록 (sitemap용)
+    // GET /posts/slugs - 발행된 글 slug 목록 (sitemap용)
     typedFastify.get(
       "/slugs",
       {
@@ -96,7 +96,7 @@ export function createPostRoute(postService: PostService): FastifyPluginAsync {
       },
     );
 
-    // GET /api/posts/:slug - 게시글 상세 조회 (Public)
+    // GET /posts/:slug - 게시글 상세 조회 (Public)
     typedFastify.get(
       "/:slug",
       {
@@ -151,7 +151,7 @@ export function createAdminPostRoute(
   ) => {
     const typedFastify = fastify.withTypeProvider<ZodTypeProvider>();
 
-    // GET /api/admin/posts - 게시글 목록 조회 (Admin)
+    // GET /admin/posts - 게시글 목록 조회 (Admin)
     typedFastify.get(
       "/",
       {
@@ -192,7 +192,7 @@ export function createAdminPostRoute(
       },
     );
 
-    // GET /api/admin/posts/pinned-count - pinned 게시글 수 조회 (Admin)
+    // GET /admin/posts/pinned-count - pinned 게시글 수 조회 (Admin)
     typedFastify.get(
       "/pinned-count",
       {
@@ -216,7 +216,7 @@ export function createAdminPostRoute(
       },
     );
 
-    // GET /api/admin/posts/:id - 게시글 상세 조회 (Admin)
+    // GET /admin/posts/:id - 게시글 상세 조회 (Admin)
     typedFastify.get(
       "/:id",
       {
@@ -253,7 +253,7 @@ export function createAdminPostRoute(
       },
     );
 
-    // POST /api/admin/posts - 게시글 생성 (Admin)
+    // POST /admin/posts - 게시글 생성 (Admin)
     typedFastify.post(
       "/",
       {
@@ -263,7 +263,7 @@ export function createAdminPostRoute(
           summary: "Create post (Admin)",
           description:
             "새 게시글을 생성합니다. 태그는 자동으로 생성/연결됩니다.\n\n" +
-            "**CSRF 토큰 필요**: `GET /api/auth/csrf-token`으로 토큰을 발급받아 " +
+            "**CSRF 토큰 필요**: `GET /auth/csrf-token`으로 토큰을 발급받아 " +
             "`x-csrf-token` 헤더에 포함해야 합니다.",
           security: [{ cookieAuth: [] }],
           body: CreatePostBodySchema,
@@ -309,7 +309,7 @@ export function createAdminPostRoute(
       },
     );
 
-    // PATCH /api/admin/posts/bulk - 게시글 벌크 작업 (Admin)
+    // PATCH /admin/posts/bulk - 게시글 벌크 작업 (Admin)
     typedFastify.patch(
       "/bulk",
       {
@@ -319,7 +319,7 @@ export function createAdminPostRoute(
           summary: "Bulk action on posts (Admin)",
           description:
             "여러 게시글에 대해 일괄 작업을 수행합니다. 단일 트랜잭션으로 전체 성공 or 전체 실패합니다.\n\n" +
-            "**CSRF 토큰 필요**: `GET /api/auth/csrf-token`으로 토큰을 발급받아 " +
+            "**CSRF 토큰 필요**: `GET /auth/csrf-token`으로 토큰을 발급받아 " +
             "`x-csrf-token` 헤더에 포함해야 합니다.",
           security: [{ cookieAuth: [] }],
           body: BulkPostActionBodySchema,
@@ -345,7 +345,7 @@ export function createAdminPostRoute(
       },
     );
 
-    // PATCH /api/admin/posts/:id - 게시글 수정 (Admin)
+    // PATCH /admin/posts/:id - 게시글 수정 (Admin)
     typedFastify.patch(
       "/:id",
       {
@@ -355,7 +355,7 @@ export function createAdminPostRoute(
           summary: "Update post (Admin)",
           description:
             "게시글을 수정합니다. 수정할 필드만 전달하면 됩니다. tags를 전달하면 기존 태그를 덮어씁니다.\n\n" +
-            "**CSRF 토큰 필요**: `GET /api/auth/csrf-token`으로 토큰을 발급받아 " +
+            "**CSRF 토큰 필요**: `GET /auth/csrf-token`으로 토큰을 발급받아 " +
             "`x-csrf-token` 헤더에 포함해야 합니다.",
           security: [{ cookieAuth: [] }],
           params: PostIdParamSchema,
@@ -396,7 +396,7 @@ export function createAdminPostRoute(
       },
     );
 
-    // DELETE /api/admin/posts/:id - 게시글 Soft Delete (Admin)
+    // DELETE /admin/posts/:id - 게시글 Soft Delete (Admin)
     typedFastify.delete(
       "/:id",
       {
@@ -406,7 +406,7 @@ export function createAdminPostRoute(
           summary: "Delete post (Soft Delete) (Admin)",
           description:
             "게시글을 Soft Delete합니다. deletedAt 타임스탬프가 설정됩니다.\n\n" +
-            "**CSRF 토큰 필요**: `GET /api/auth/csrf-token`으로 토큰을 발급받아 " +
+            "**CSRF 토큰 필요**: `GET /auth/csrf-token`으로 토큰을 발급받아 " +
             "`x-csrf-token` 헤더에 포함해야 합니다.",
           security: [{ cookieAuth: [] }],
           params: PostIdParamSchema,
@@ -426,7 +426,7 @@ export function createAdminPostRoute(
       },
     );
 
-    // PUT /api/admin/posts/:id/restore - 게시글 복원 (Admin)
+    // PUT /admin/posts/:id/restore - 게시글 복원 (Admin)
     typedFastify.put(
       "/:id/restore",
       {
@@ -436,7 +436,7 @@ export function createAdminPostRoute(
           summary: "Restore deleted post (Admin)",
           description:
             "Soft Delete된 게시글을 복원합니다.\n\n" +
-            "**CSRF 토큰 필요**: `GET /api/auth/csrf-token`으로 토큰을 발급받아 " +
+            "**CSRF 토큰 필요**: `GET /auth/csrf-token`으로 토큰을 발급받아 " +
             "`x-csrf-token` 헤더에 포함해야 합니다.",
           security: [{ cookieAuth: [] }],
           params: PostIdParamSchema,
@@ -466,7 +466,7 @@ export function createAdminPostRoute(
       },
     );
 
-    // DELETE /api/admin/posts/:id/hard - 게시글 Hard Delete (Admin)
+    // DELETE /admin/posts/:id/hard - 게시글 Hard Delete (Admin)
     typedFastify.delete(
       "/:id/hard",
       {
@@ -476,7 +476,7 @@ export function createAdminPostRoute(
           summary: "Hard delete post (Admin)",
           description:
             "게시글을 완전히 삭제합니다. 복구할 수 없습니다. 연결된 태그 관계도 삭제됩니다.\n\n" +
-            "**CSRF 토큰 필요**: `GET /api/auth/csrf-token`으로 토큰을 발급받아 " +
+            "**CSRF 토큰 필요**: `GET /auth/csrf-token`으로 토큰을 발급받아 " +
             "`x-csrf-token` 헤더에 포함해야 합니다.",
           security: [{ cookieAuth: [] }],
           params: PostIdParamSchema,

--- a/src/routes/settings/settings.route.ts
+++ b/src/routes/settings/settings.route.ts
@@ -20,7 +20,7 @@ export function createSettingsRoute(
   ) => {
     const typedFastify = fastify.withTypeProvider<ZodTypeProvider>();
 
-    // GET /api/settings/guestbook - 방명록 활성 상태 조회
+    // GET /settings/guestbook - 방명록 활성 상태 조회
     typedFastify.get(
       "/guestbook",
       {
@@ -55,7 +55,7 @@ export function createAdminSettingsRoute(
   ) => {
     const typedFastify = fastify.withTypeProvider<ZodTypeProvider>();
 
-    // PATCH /api/admin/settings/guestbook - 방명록 활성 상태 변경
+    // PATCH /admin/settings/guestbook - 방명록 활성 상태 변경
     typedFastify.patch(
       "/settings/guestbook",
       {
@@ -64,7 +64,7 @@ export function createAdminSettingsRoute(
           summary: "방명록 활성 상태 변경",
           description:
             "방명록 기능의 활성 상태를 변경합니다.\n\n" +
-            "**CSRF 토큰 필요**: `GET /api/auth/csrf-token`으로 토큰을 발급받아 " +
+            "**CSRF 토큰 필요**: `GET /auth/csrf-token`으로 토큰을 발급받아 " +
             "`x-csrf-token` 헤더에 포함해야 합니다.",
           security: [{ cookieAuth: [] }],
           body: UpdateGuestbookSettingsBodySchema,

--- a/src/routes/stats/stats.route.ts
+++ b/src/routes/stats/stats.route.ts
@@ -22,7 +22,7 @@ export function createStatsRoute(
   const statsRoute: FastifyPluginAsync = async (fastify: FastifyInstance) => {
     const typedFastify = fastify.withTypeProvider<ZodTypeProvider>();
 
-    // POST /api/stats/view - 페이지 조회수 기록
+    // POST /stats/view - 페이지 조회수 기록
     typedFastify.post(
       "/view",
       {
@@ -38,7 +38,7 @@ export function createStatsRoute(
           summary: "조회수 기록",
           description:
             "게시글 조회수를 기록합니다. 동일 IP의 5분 이내 중복 요청은 집계에서 제외됩니다.\n\n" +
-            "**CSRF 토큰 필요**: `GET /api/auth/csrf-token`으로 토큰을 발급받아 " +
+            "**CSRF 토큰 필요**: `GET /auth/csrf-token`으로 토큰을 발급받아 " +
             "`x-csrf-token` 헤더에 포함해야 합니다.\n\n" +
             "**Rate limit**: 30회/분",
           body: StatsViewBodySchema,
@@ -64,7 +64,7 @@ export function createStatsRoute(
       },
     );
 
-    // GET /api/stats/popular - 인기 게시글 조회
+    // GET /stats/popular - 인기 게시글 조회
     typedFastify.get(
       "/popular",
       {
@@ -88,7 +88,7 @@ export function createStatsRoute(
       },
     );
 
-    // GET /api/stats/total-views - 사이트 전체 누적 조회수
+    // GET /stats/total-views - 사이트 전체 누적 조회수
     typedFastify.get(
       "/total-views",
       {
@@ -127,7 +127,7 @@ export function createAdminStatsRoute(
   ) => {
     const typedFastify = fastify.withTypeProvider<ZodTypeProvider>();
 
-    // GET /api/admin/stats/dashboard - 통계 대시보드
+    // GET /admin/stats/dashboard - 통계 대시보드
     typedFastify.get(
       "/dashboard",
       {

--- a/src/routes/user/user.route.ts
+++ b/src/routes/user/user.route.ts
@@ -17,7 +17,7 @@ export function createUserRoute(userService: UserService): FastifyPluginAsync {
   const userRoute: FastifyPluginAsync = async (fastify: FastifyInstance) => {
     const typedFastify = fastify.withTypeProvider<ZodTypeProvider>();
 
-    // GET /api/user/me — 내 프로필 조회
+    // GET /user/me — 내 프로필 조회
     typedFastify.get(
       "/me",
       {
@@ -42,7 +42,7 @@ export function createUserRoute(userService: UserService): FastifyPluginAsync {
       },
     );
 
-    // PUT /api/user/me — 내 프로필 수정
+    // PUT /user/me — 내 프로필 수정
     typedFastify.put(
       "/me",
       {
@@ -71,7 +71,7 @@ export function createUserRoute(userService: UserService): FastifyPluginAsync {
       },
     );
 
-    // DELETE /api/user/me — 회원 탈퇴
+    // DELETE /user/me — 회원 탈퇴
     typedFastify.delete(
       "/me",
       {

--- a/test/helpers/app.ts
+++ b/test/helpers/app.ts
@@ -35,7 +35,7 @@ export async function injectAuth(
 ): Promise<string> {
   const response = await app.inject({
     method: "POST",
-    url: "/api/auth/admin/login",
+    url: "/auth/admin/login",
     payload: {
       username: TEST_ADMIN_USERNAME,
       password: TEST_ADMIN_PASSWORD,

--- a/test/routes/assets.test.ts
+++ b/test/routes/assets.test.ts
@@ -84,18 +84,18 @@ describe("Asset Routes", () => {
     authCookie = await injectAuth(app);
   });
 
-  // ===== GET /api/assets =====
+  // ===== GET /assets =====
 
-  describe("GET /api/assets", () => {
+  describe("GET /assets", () => {
     it("인증 없이 → 403", async () => {
-      const res = await app.inject({ method: "GET", url: "/api/assets" });
+      const res = await app.inject({ method: "GET", url: "/assets" });
       expect(res.statusCode).toBe(403);
     });
 
     it("빈 목록 → 200 + data[]", async () => {
       const res = await app.inject({
         method: "GET",
-        url: "/api/assets",
+        url: "/assets",
         headers: { cookie: authCookie },
       });
       expect(res.statusCode).toBe(200);
@@ -109,7 +109,7 @@ describe("Asset Routes", () => {
 
       const res = await app.inject({
         method: "GET",
-        url: "/api/assets?page=1&limit=2",
+        url: "/assets?page=1&limit=2",
         headers: { cookie: authCookie },
       });
       expect(res.statusCode).toBe(200);
@@ -124,9 +124,9 @@ describe("Asset Routes", () => {
     });
   });
 
-  // ===== POST /api/assets/upload =====
+  // ===== POST /assets/upload =====
 
-  describe("POST /api/assets/upload", () => {
+  describe("POST /assets/upload", () => {
     afterEach(async () => {
       // 업로드된 파일 정리
       const uploadDir = getUploadDir();
@@ -144,7 +144,7 @@ describe("Asset Routes", () => {
         method: "POST",
       });
 
-      expectRouteHasOnRequestHook(routes, "/api/assets/upload", "POST");
+      expectRouteHasOnRequestHook(routes, "/assets/upload", "POST");
     });
 
     it("인증 없이 → 403", async () => {
@@ -155,7 +155,7 @@ describe("Asset Routes", () => {
       );
       const res = await app.inject({
         method: "POST",
-        url: "/api/assets/upload",
+        url: "/assets/upload",
         headers: { "content-type": `multipart/form-data; boundary=${boundary}` },
         payload,
       });
@@ -170,7 +170,7 @@ describe("Asset Routes", () => {
       );
       const res = await app.inject({
         method: "POST",
-        url: "/api/assets/upload",
+        url: "/assets/upload",
         headers: {
           cookie: authCookie,
           "content-type": `multipart/form-data; boundary=${boundary}`,
@@ -195,7 +195,7 @@ describe("Asset Routes", () => {
       );
       const uploadRes = await app.inject({
         method: "POST",
-        url: "/api/assets/upload",
+        url: "/assets/upload",
         headers: {
           cookie: authCookie,
           "content-type": `multipart/form-data; boundary=${boundary}`,
@@ -229,7 +229,7 @@ describe("Asset Routes", () => {
       );
       const res = await app.inject({
         method: "POST",
-        url: "/api/assets/upload",
+        url: "/assets/upload",
         headers: {
           cookie: authCookie,
           "content-type": `multipart/form-data; boundary=${boundary}`,
@@ -250,7 +250,7 @@ describe("Asset Routes", () => {
       );
       const res = await app.inject({
         method: "POST",
-        url: "/api/assets/upload",
+        url: "/assets/upload",
         headers: {
           cookie: authCookie,
           "content-type": `multipart/form-data; boundary=${boundary}`,
@@ -268,7 +268,7 @@ describe("Asset Routes", () => {
       );
       const res = await app.inject({
         method: "POST",
-        url: "/api/assets/upload",
+        url: "/assets/upload",
         headers: {
           cookie: authCookie,
           "content-type": `multipart/form-data; boundary=${boundary}`,
@@ -286,7 +286,7 @@ describe("Asset Routes", () => {
       );
       const res = await app.inject({
         method: "POST",
-        url: "/api/assets/upload",
+        url: "/assets/upload",
         headers: {
           cookie: authCookie,
           "content-type": `multipart/form-data; boundary=${boundary}`,
@@ -304,7 +304,7 @@ describe("Asset Routes", () => {
       );
       const res = await app.inject({
         method: "POST",
-        url: "/api/assets/upload",
+        url: "/assets/upload",
         headers: {
           cookie: authCookie,
           "content-type": `multipart/form-data; boundary=${boundary}`,
@@ -319,7 +319,7 @@ describe("Asset Routes", () => {
       const payload = Buffer.from(`--${boundary}--\r\n`);
       const res = await app.inject({
         method: "POST",
-        url: "/api/assets/upload",
+        url: "/assets/upload",
         headers: {
           cookie: authCookie,
           "content-type": `multipart/form-data; boundary=${boundary}`,
@@ -338,7 +338,7 @@ describe("Asset Routes", () => {
       );
       const res = await app.inject({
         method: "POST",
-        url: "/api/assets/upload",
+        url: "/assets/upload",
         headers: {
           cookie: authCookie,
           "content-type": `multipart/form-data; boundary=${boundary}`,
@@ -349,14 +349,14 @@ describe("Asset Routes", () => {
     });
   });
 
-  // ===== GET /api/assets/:id =====
+  // ===== GET /assets/:id =====
 
-  describe("GET /api/assets/:id", () => {
+  describe("GET /assets/:id", () => {
     it("존재하는 asset → 200", async () => {
       const asset = await seedAsset({ width: 800, height: 600 });
       const res = await app.inject({
         method: "GET",
-        url: `/api/assets/${asset.id}`,
+        url: `/assets/${asset.id}`,
       });
       expect(res.statusCode).toBe(200);
       const body = res.json();
@@ -369,15 +369,15 @@ describe("Asset Routes", () => {
     it("없는 id → 404", async () => {
       const res = await app.inject({
         method: "GET",
-        url: "/api/assets/999999",
+        url: "/assets/999999",
       });
       expect(res.statusCode).toBe(404);
     });
   });
 
-  // ===== DELETE /api/assets/:id =====
+  // ===== DELETE /assets/:id =====
 
-  describe("DELETE /api/assets/:id", () => {
+  describe("DELETE /assets/:id", () => {
     it("route에 CSRF onRequest hook 등록", () => {
       const routes = app.printRoutes({
         commonPrefix: false,
@@ -385,14 +385,14 @@ describe("Asset Routes", () => {
         method: "DELETE",
       });
 
-      expectRouteHasOnRequestHook(routes, "/api/assets/:id", "DELETE");
+      expectRouteHasOnRequestHook(routes, "/assets/:id", "DELETE");
     });
 
     it("인증 없이 → 403", async () => {
       const asset = await seedAsset();
       const res = await app.inject({
         method: "DELETE",
-        url: `/api/assets/${asset.id}`,
+        url: `/assets/${asset.id}`,
       });
       expect(res.statusCode).toBe(403);
     });
@@ -401,7 +401,7 @@ describe("Asset Routes", () => {
       const asset = await seedAsset();
       const res = await app.inject({
         method: "DELETE",
-        url: `/api/assets/${asset.id}`,
+        url: `/assets/${asset.id}`,
         headers: { cookie: authCookie },
       });
       expect(res.statusCode).toBe(204);
@@ -409,7 +409,7 @@ describe("Asset Routes", () => {
       // 삭제 후 조회 → 404
       const check = await app.inject({
         method: "GET",
-        url: `/api/assets/${asset.id}`,
+        url: `/assets/${asset.id}`,
       });
       expect(check.statusCode).toBe(404);
     });
@@ -417,16 +417,16 @@ describe("Asset Routes", () => {
     it("없는 id → 404", async () => {
       const res = await app.inject({
         method: "DELETE",
-        url: "/api/assets/999999",
+        url: "/assets/999999",
         headers: { cookie: authCookie },
       });
       expect(res.statusCode).toBe(404);
     });
   });
 
-  // ===== DELETE /api/assets/bulk =====
+  // ===== DELETE /assets/bulk =====
 
-  describe("DELETE /api/assets/bulk", () => {
+  describe("DELETE /assets/bulk", () => {
     it("route에 CSRF onRequest hook 등록", () => {
       const routes = app.printRoutes({
         commonPrefix: false,
@@ -434,13 +434,13 @@ describe("Asset Routes", () => {
         method: "DELETE",
       });
 
-      expectRouteHasOnRequestHook(routes, "/api/assets/bulk", "DELETE");
+      expectRouteHasOnRequestHook(routes, "/assets/bulk", "DELETE");
     });
 
     it("인증 없이 → 403", async () => {
       const res = await app.inject({
         method: "DELETE",
-        url: "/api/assets/bulk",
+        url: "/assets/bulk",
         payload: { ids: [1] },
       });
       expect(res.statusCode).toBe(403);
@@ -455,27 +455,27 @@ describe("Asset Routes", () => {
 
       const res = await app.inject({
         method: "DELETE",
-        url: "/api/assets/bulk",
+        url: "/assets/bulk",
         headers: { cookie: authCookie },
         payload: { ids: [a1.id, a2.id] },
       });
       expect(res.statusCode).toBe(204);
 
       // 삭제된 id 조회 → 404
-      const check1 = await app.inject({ method: "GET", url: `/api/assets/${a1.id}` });
-      const check2 = await app.inject({ method: "GET", url: `/api/assets/${a2.id}` });
+      const check1 = await app.inject({ method: "GET", url: `/assets/${a1.id}` });
+      const check2 = await app.inject({ method: "GET", url: `/assets/${a2.id}` });
       expect(check1.statusCode).toBe(404);
       expect(check2.statusCode).toBe(404);
 
       // 삭제 안 된 id는 유지
-      const check3 = await app.inject({ method: "GET", url: `/api/assets/${a3.id}` });
+      const check3 = await app.inject({ method: "GET", url: `/assets/${a3.id}` });
       expect(check3.statusCode).toBe(200);
     });
 
     it("ids 없이 → 400", async () => {
       const res = await app.inject({
         method: "DELETE",
-        url: "/api/assets/bulk",
+        url: "/assets/bulk",
         headers: { cookie: authCookie },
         payload: { ids: [] },
       });

--- a/test/routes/auth.test.ts
+++ b/test/routes/auth.test.ts
@@ -24,7 +24,7 @@ describe("Auth Routes", () => {
   async function getCsrfHeaders(cookie?: string): Promise<Record<string, string>> {
     const response = await app.inject({
       method: "GET",
-      url: "/api/auth/csrf-token",
+      url: "/auth/csrf-token",
       headers: cookie ? { cookie } : undefined,
     });
     const responseCookie = response.headers["set-cookie"];
@@ -52,9 +52,9 @@ describe("Auth Routes", () => {
     await truncateAll();
   });
 
-  // ===== POST /api/auth/admin/login =====
+  // ===== POST /auth/admin/login =====
 
-  describe("POST /api/auth/admin/login", () => {
+  describe("POST /auth/admin/login", () => {
     beforeEach(async () => {
       await seedAdmin();
     });
@@ -62,7 +62,7 @@ describe("Auth Routes", () => {
     it("올바른 자격증명 → 200 + 세션 쿠키", async () => {
       const response = await app.inject({
         method: "POST",
-        url: "/api/auth/admin/login",
+        url: "/auth/admin/login",
         payload: {
           username: TEST_ADMIN_USERNAME,
           password: TEST_ADMIN_PASSWORD,
@@ -84,7 +84,7 @@ describe("Auth Routes", () => {
     it("잘못된 비밀번호 → 401", async () => {
       const response = await app.inject({
         method: "POST",
-        url: "/api/auth/admin/login",
+        url: "/auth/admin/login",
         payload: {
           username: TEST_ADMIN_USERNAME,
           password: "WrongPassword1!",
@@ -97,7 +97,7 @@ describe("Auth Routes", () => {
     it("존재하지 않는 사용자명 → 401", async () => {
       const response = await app.inject({
         method: "POST",
-        url: "/api/auth/admin/login",
+        url: "/auth/admin/login",
         payload: {
           username: "missing-user",
           password: TEST_ADMIN_PASSWORD,
@@ -113,7 +113,7 @@ describe("Auth Routes", () => {
 
       const response = await app.inject({
         method: "POST",
-        url: "/api/auth/admin/login",
+        url: "/auth/admin/login",
         payload: {
           username: "Admin@Test.pyosh.dev",
           password: TEST_ADMIN_PASSWORD,
@@ -130,7 +130,7 @@ describe("Auth Routes", () => {
     it("legacy email 필드를 보내면 → 400", async () => {
       const response = await app.inject({
         method: "POST",
-        url: "/api/auth/admin/login",
+        url: "/auth/admin/login",
         payload: {
           username: TEST_ADMIN_USERNAME,
           email: TEST_ADMIN_USERNAME,
@@ -144,7 +144,7 @@ describe("Auth Routes", () => {
     it("username에 공백이 포함되면 → 400", async () => {
       const response = await app.inject({
         method: "POST",
-        url: "/api/auth/admin/login",
+        url: "/auth/admin/login",
         payload: {
           username: "admin user",
           password: TEST_ADMIN_PASSWORD,
@@ -157,7 +157,7 @@ describe("Auth Routes", () => {
     it("username이 100자를 초과하면 → 400", async () => {
       const response = await app.inject({
         method: "POST",
-        url: "/api/auth/admin/login",
+        url: "/auth/admin/login",
         payload: {
           username: "a".repeat(101),
           password: TEST_ADMIN_PASSWORD,
@@ -172,7 +172,7 @@ describe("Auth Routes", () => {
 
       const response = await app.inject({
         method: "POST",
-        url: "/api/auth/admin/login",
+        url: "/auth/admin/login",
         payload: {
           username: TEST_ADMIN_USERNAME,
           password: TEST_ADMIN_PASSWORD,
@@ -186,13 +186,13 @@ describe("Auth Routes", () => {
     });
   });
 
-  // ===== GET /api/auth/csrf-token =====
+  // ===== GET /auth/csrf-token =====
 
-  describe("GET /api/auth/csrf-token", () => {
+  describe("GET /auth/csrf-token", () => {
     it("CSRF 토큰 발급 + 세션 쿠키 설정 → 200", async () => {
       const response = await app.inject({
         method: "GET",
-        url: "/api/auth/csrf-token",
+        url: "/auth/csrf-token",
       });
 
       expect(response.statusCode).toBe(200);
@@ -200,15 +200,15 @@ describe("Auth Routes", () => {
     });
   });
 
-  // ===== GET /api/auth/me =====
+  // ===== GET /auth/me =====
 
-  describe("GET /api/auth/me", () => {
+  describe("GET /auth/me", () => {
     it("로그인 상태 → 200", async () => {
       await seedAdmin();
 
       const loginResponse = await app.inject({
         method: "POST",
-        url: "/api/auth/admin/login",
+        url: "/auth/admin/login",
         payload: {
           username: TEST_ADMIN_USERNAME,
           password: TEST_ADMIN_PASSWORD,
@@ -219,7 +219,7 @@ describe("Auth Routes", () => {
 
       const response = await app.inject({
         method: "GET",
-        url: "/api/auth/me",
+        url: "/auth/me",
         headers: { cookie: sessionCookie },
       });
 
@@ -234,22 +234,22 @@ describe("Auth Routes", () => {
     it("비로그인 → 401", async () => {
       const response = await app.inject({
         method: "GET",
-        url: "/api/auth/me",
+        url: "/auth/me",
       });
 
       expect(response.statusCode).toBe(401);
     });
   });
 
-  // ===== POST /api/auth/admin/logout =====
+  // ===== POST /auth/admin/logout =====
 
-  describe("POST /api/auth/admin/logout", () => {
+  describe("POST /auth/admin/logout", () => {
     it("세션 파기 → 204, 이후 /me → 401", async () => {
       await seedAdmin();
 
       const loginResponse = await app.inject({
         method: "POST",
-        url: "/api/auth/admin/login",
+        url: "/auth/admin/login",
         payload: {
           username: TEST_ADMIN_USERNAME,
           password: TEST_ADMIN_PASSWORD,
@@ -261,7 +261,7 @@ describe("Auth Routes", () => {
 
       const logoutResponse = await app.inject({
         method: "POST",
-        url: "/api/auth/admin/logout",
+        url: "/auth/admin/logout",
         headers: csrfHeaders,
       });
 
@@ -270,7 +270,7 @@ describe("Auth Routes", () => {
       // 세션 파기 후 /me 요청은 401
       const meResponse = await app.inject({
         method: "GET",
-        url: "/api/auth/me",
+        url: "/auth/me",
         headers: { cookie: sessionCookie },
       });
 

--- a/test/routes/categories.test.ts
+++ b/test/routes/categories.test.ts
@@ -40,13 +40,13 @@ describe("Category Routes", () => {
     await truncateAll();
   });
 
-  // ===== GET /api/categories =====
+  // ===== GET /categories =====
 
-  describe("GET /api/categories", () => {
+  describe("GET /categories", () => {
     it("빈 목록 → 200 + []", async () => {
       const response = await app.inject({
         method: "GET",
-        url: "/api/categories",
+        url: "/categories",
       });
 
       expect(response.statusCode).toBe(200);
@@ -61,7 +61,7 @@ describe("Category Routes", () => {
 
       const response = await app.inject({
         method: "GET",
-        url: "/api/categories",
+        url: "/categories",
       });
 
       expect(response.statusCode).toBe(200);
@@ -80,7 +80,7 @@ describe("Category Routes", () => {
 
       const response = await app.inject({
         method: "GET",
-        url: "/api/categories",
+        url: "/categories",
       });
 
       expect(response.statusCode).toBe(200);
@@ -97,16 +97,16 @@ describe("Category Routes", () => {
     it("slug 단건 조회 경로 제거됨 → 404", async () => {
       const response = await app.inject({
         method: "GET",
-        url: "/api/categories/some-category",
+        url: "/categories/some-category",
       });
 
       expect(response.statusCode).toBe(404);
     });
   });
 
-  // ===== POST /api/categories =====
+  // ===== POST /categories =====
 
-  describe("POST /api/categories", () => {
+  describe("POST /categories", () => {
     it("route에 CSRF onRequest hook 등록", () => {
       const routes = app.printRoutes({
         commonPrefix: false,
@@ -114,7 +114,7 @@ describe("Category Routes", () => {
         method: "POST",
       });
 
-      expectRouteHasOnRequestHook(routes, "/api/categories", "POST");
+      expectRouteHasOnRequestHook(routes, "/categories", "POST");
     });
 
     it("Admin 생성 성공 → 201", async () => {
@@ -123,7 +123,7 @@ describe("Category Routes", () => {
 
       const response = await app.inject({
         method: "POST",
-        url: "/api/categories",
+        url: "/categories",
         headers: { cookie },
         payload: {
           name: "New Category",
@@ -145,7 +145,7 @@ describe("Category Routes", () => {
     it("비인증 → 403", async () => {
       const response = await app.inject({
         method: "POST",
-        url: "/api/categories",
+        url: "/categories",
         payload: {
           name: "Unauthorized Category",
         },
@@ -155,9 +155,9 @@ describe("Category Routes", () => {
     });
   });
 
-  // ===== PATCH /api/categories/:id =====
+  // ===== PATCH /categories/:id =====
 
-  describe("PATCH /api/categories/:id", () => {
+  describe("PATCH /categories/:id", () => {
     it("route에 CSRF onRequest hook 등록", () => {
       const routes = app.printRoutes({
         commonPrefix: false,
@@ -165,7 +165,7 @@ describe("Category Routes", () => {
         method: "PATCH",
       });
 
-      expectRouteHasOnRequestHook(routes, "/api/categories/:id", "PATCH");
+      expectRouteHasOnRequestHook(routes, "/categories/:id", "PATCH");
     });
 
     it("이름 변경", async () => {
@@ -175,7 +175,7 @@ describe("Category Routes", () => {
 
       const response = await app.inject({
         method: "PATCH",
-        url: `/api/categories/${category.id}`,
+        url: `/categories/${category.id}`,
         headers: { cookie },
         payload: {
           name: "Updated Name",
@@ -190,9 +190,9 @@ describe("Category Routes", () => {
     });
   });
 
-  // ===== PATCH /api/categories/tree =====
+  // ===== PATCH /categories/tree =====
 
-  describe("PATCH /api/categories/tree", () => {
+  describe("PATCH /categories/tree", () => {
     it("route에 CSRF onRequest hook 등록", () => {
       const routes = app.printRoutes({
         commonPrefix: false,
@@ -200,7 +200,7 @@ describe("Category Routes", () => {
         method: "PATCH",
       });
 
-      expectRouteHasOnRequestHook(routes, "/api/categories/tree", "PATCH");
+      expectRouteHasOnRequestHook(routes, "/categories/tree", "PATCH");
     });
 
     it("트리 배치 변경 → 200", async () => {
@@ -211,7 +211,7 @@ describe("Category Routes", () => {
 
       const response = await app.inject({
         method: "PATCH",
-        url: "/api/categories/tree",
+        url: "/categories/tree",
         headers: { cookie },
         payload: {
           changes: [
@@ -230,7 +230,7 @@ describe("Category Routes", () => {
     it("비인증 → 403", async () => {
       const response = await app.inject({
         method: "PATCH",
-        url: "/api/categories/tree",
+        url: "/categories/tree",
         payload: {
           changes: [{ id: 999999, parentId: null, sortOrder: 0 }],
         },
@@ -247,7 +247,7 @@ describe("Category Routes", () => {
 
       const response = await app.inject({
         method: "PATCH",
-        url: "/api/categories/tree",
+        url: "/categories/tree",
         headers: { cookie },
         payload: {
           changes: [
@@ -268,7 +268,7 @@ describe("Category Routes", () => {
 
       const response = await app.inject({
         method: "PATCH",
-        url: "/api/categories/tree",
+        url: "/categories/tree",
         headers: { cookie },
         payload: {
           changes: [
@@ -288,7 +288,7 @@ describe("Category Routes", () => {
 
       const response = await app.inject({
         method: "PATCH",
-        url: "/api/categories/tree",
+        url: "/categories/tree",
         headers: { cookie },
         payload: {
           changes: [{ id: a.id, parentId: a.id, sortOrder: 0 }],
@@ -299,9 +299,9 @@ describe("Category Routes", () => {
     });
   });
 
-  // ===== DELETE /api/categories/:id =====
+  // ===== DELETE /categories/:id =====
 
-  describe("DELETE /api/categories/:id", () => {
+  describe("DELETE /categories/:id", () => {
     it("route에 CSRF onRequest hook 등록", () => {
       const routes = app.printRoutes({
         commonPrefix: false,
@@ -309,7 +309,7 @@ describe("Category Routes", () => {
         method: "DELETE",
       });
 
-      expectRouteHasOnRequestHook(routes, "/api/categories/:id", "DELETE");
+      expectRouteHasOnRequestHook(routes, "/categories/:id", "DELETE");
     });
 
     it("하위 카테고리 있으면 409", async () => {
@@ -320,7 +320,7 @@ describe("Category Routes", () => {
 
       const response = await app.inject({
         method: "DELETE",
-        url: `/api/categories/${parent.id}?action=trash`,
+        url: `/categories/${parent.id}?action=trash`,
         headers: { cookie },
       });
 
@@ -334,7 +334,7 @@ describe("Category Routes", () => {
 
       const response = await app.inject({
         method: "DELETE",
-        url: `/api/categories/${category.id}?action=trash`,
+        url: `/categories/${category.id}?action=trash`,
         headers: { cookie },
       });
 
@@ -349,7 +349,7 @@ describe("Category Routes", () => {
 
       const response = await app.inject({
         method: "DELETE",
-        url: `/api/categories/${category.id}?action=trash`,
+        url: `/categories/${category.id}?action=trash`,
         headers: { cookie },
       });
 
@@ -372,7 +372,7 @@ describe("Category Routes", () => {
 
       const response = await app.inject({
         method: "DELETE",
-        url: `/api/categories/${source.id}?action=move&moveTo=${target.id}`,
+        url: `/categories/${source.id}?action=move&moveTo=${target.id}`,
         headers: { cookie },
       });
 
@@ -392,7 +392,7 @@ describe("Category Routes", () => {
 
       const response = await app.inject({
         method: "DELETE",
-        url: `/api/categories/${category.id}?action=move`,
+        url: `/categories/${category.id}?action=move`,
         headers: { cookie },
       });
 
@@ -406,7 +406,7 @@ describe("Category Routes", () => {
 
       const response = await app.inject({
         method: "DELETE",
-        url: `/api/categories/${category.id}`,
+        url: `/categories/${category.id}`,
         headers: { cookie },
       });
 
@@ -420,7 +420,7 @@ describe("Category Routes", () => {
 
       const response = await app.inject({
         method: "DELETE",
-        url: `/api/categories/${category.id}?action=move&moveTo=999999`,
+        url: `/categories/${category.id}?action=move&moveTo=999999`,
         headers: { cookie },
       });
 
@@ -434,7 +434,7 @@ describe("Category Routes", () => {
 
       const response = await app.inject({
         method: "DELETE",
-        url: `/api/categories/${category.id}?action=move&moveTo=${category.id}`,
+        url: `/categories/${category.id}?action=move&moveTo=${category.id}`,
         headers: { cookie },
       });
 

--- a/test/routes/comments.test.ts
+++ b/test/routes/comments.test.ts
@@ -33,9 +33,9 @@ describe("Comment Routes", () => {
     await truncateAll();
   });
 
-  // ===== POST /api/posts/:postId/comments =====
+  // ===== POST /posts/:postId/comments =====
 
-  describe("POST /api/posts/:postId/comments", () => {
+  describe("POST /posts/:postId/comments", () => {
     it("게스트 댓글 작성 → 201", async () => {
       const category = await seedCategory();
       const post = await seedPost(category.id, {
@@ -45,7 +45,7 @@ describe("Comment Routes", () => {
 
       const response = await app.inject({
         method: "POST",
-        url: `/api/posts/${post.id}/comments`,
+        url: `/posts/${post.id}/comments`,
         payload: {
           body: "게스트 댓글입니다.",
           guestName: "홍길동",
@@ -74,7 +74,7 @@ describe("Comment Routes", () => {
 
       const response = await app.inject({
         method: "POST",
-        url: `/api/posts/${post.id}/comments`,
+        url: `/posts/${post.id}/comments`,
         payload: {
           body: "게스트 비밀 댓글입니다.",
           guestName: "홍길동",
@@ -104,7 +104,7 @@ describe("Comment Routes", () => {
 
       const response = await app.inject({
         method: "POST",
-        url: `/api/posts/${post.id}/comments`,
+        url: `/posts/${post.id}/comments`,
         headers: { cookie },
         payload: {
           body: "OAuth 댓글입니다.",
@@ -132,7 +132,7 @@ describe("Comment Routes", () => {
       // 루트 댓글 작성
       const rootResponse = await app.inject({
         method: "POST",
-        url: `/api/posts/${post.id}/comments`,
+        url: `/posts/${post.id}/comments`,
         payload: {
           body: "루트 댓글입니다.",
           guestName: "부모",
@@ -146,7 +146,7 @@ describe("Comment Routes", () => {
       // 대댓글 작성
       const replyResponse = await app.inject({
         method: "POST",
-        url: `/api/posts/${post.id}/comments`,
+        url: `/posts/${post.id}/comments`,
         payload: {
           body: "대댓글입니다.",
           parentId: rootComment.id,
@@ -173,7 +173,7 @@ describe("Comment Routes", () => {
       // 루트 댓글 (depth=0)
       const rootResponse = await app.inject({
         method: "POST",
-        url: `/api/posts/${post.id}/comments`,
+        url: `/posts/${post.id}/comments`,
         payload: {
           body: "루트 댓글",
           guestName: "A",
@@ -186,7 +186,7 @@ describe("Comment Routes", () => {
       // 대댓글 (depth=1)
       const childResponse = await app.inject({
         method: "POST",
-        url: `/api/posts/${post.id}/comments`,
+        url: `/posts/${post.id}/comments`,
         payload: {
           body: "대댓글",
           parentId: rootComment.id,
@@ -200,7 +200,7 @@ describe("Comment Routes", () => {
       // depth=2 시도 → 400
       const grandChildResponse = await app.inject({
         method: "POST",
-        url: `/api/posts/${post.id}/comments`,
+        url: `/posts/${post.id}/comments`,
         payload: {
           body: "대대댓글 시도",
           parentId: childComment.id,
@@ -214,9 +214,9 @@ describe("Comment Routes", () => {
     });
   });
 
-  // ===== GET /api/posts/:postId/comments =====
+  // ===== GET /posts/:postId/comments =====
 
-  describe("GET /api/posts/:postId/comments", () => {
+  describe("GET /posts/:postId/comments", () => {
     it("댓글 목록 조회 → 계층 구조 + 페이지네이션 메타 확인", async () => {
       const category = await seedCategory();
       const post = await seedPost(category.id, {
@@ -227,7 +227,7 @@ describe("Comment Routes", () => {
       // 루트 댓글
       const rootResponse = await app.inject({
         method: "POST",
-        url: `/api/posts/${post.id}/comments`,
+        url: `/posts/${post.id}/comments`,
         payload: {
           body: "루트 댓글",
           guestName: "루트 작성자",
@@ -240,7 +240,7 @@ describe("Comment Routes", () => {
       // 대댓글
       await app.inject({
         method: "POST",
-        url: `/api/posts/${post.id}/comments`,
+        url: `/posts/${post.id}/comments`,
         payload: {
           body: "대댓글",
           parentId: rootComment.id,
@@ -253,7 +253,7 @@ describe("Comment Routes", () => {
       // 목록 조회
       const listResponse = await app.inject({
         method: "GET",
-        url: `/api/posts/${post.id}/comments`,
+        url: `/posts/${post.id}/comments`,
       });
 
       expect(listResponse.statusCode).toBe(200);
@@ -285,7 +285,7 @@ describe("Comment Routes", () => {
       for (let i = 1; i <= 3; i++) {
         await app.inject({
           method: "POST",
-          url: `/api/posts/${post.id}/comments`,
+          url: `/posts/${post.id}/comments`,
           payload: {
             body: `댓글 ${i}`,
             guestName: `작성자${i}`,
@@ -298,7 +298,7 @@ describe("Comment Routes", () => {
       // page=1, limit=2
       const page1 = await app.inject({
         method: "GET",
-        url: `/api/posts/${post.id}/comments?page=1&limit=2`,
+        url: `/posts/${post.id}/comments?page=1&limit=2`,
       });
 
       expect(page1.statusCode).toBe(200);
@@ -310,7 +310,7 @@ describe("Comment Routes", () => {
       // page=2, limit=2
       const page2 = await app.inject({
         method: "GET",
-        url: `/api/posts/${post.id}/comments?page=2&limit=2`,
+        url: `/posts/${post.id}/comments?page=2&limit=2`,
       });
 
       expect(page2.statusCode).toBe(200);
@@ -331,7 +331,7 @@ describe("Comment Routes", () => {
       // 비밀 댓글 작성 (OAuth 사용자)
       await app.inject({
         method: "POST",
-        url: `/api/posts/${post.id}/comments`,
+        url: `/posts/${post.id}/comments`,
         headers: { cookie },
         payload: {
           body: "비밀 내용입니다.",
@@ -342,7 +342,7 @@ describe("Comment Routes", () => {
       // 비인증 조회 → 마스킹
       const publicResponse = await app.inject({
         method: "GET",
-        url: `/api/posts/${post.id}/comments`,
+        url: `/posts/${post.id}/comments`,
       });
 
       expect(publicResponse.statusCode).toBe(200);
@@ -352,7 +352,7 @@ describe("Comment Routes", () => {
       // 작성자 조회 → 원본
       const authorResponse = await app.inject({
         method: "GET",
-        url: `/api/posts/${post.id}/comments`,
+        url: `/posts/${post.id}/comments`,
         headers: { cookie },
       });
 
@@ -370,7 +370,7 @@ describe("Comment Routes", () => {
 
       const createResponse = await app.inject({
         method: "POST",
-        url: `/api/posts/${post.id}/comments`,
+        url: `/posts/${post.id}/comments`,
         payload: {
           body: "게스트 비밀 원문",
           guestName: "비밀 작성자",
@@ -384,7 +384,7 @@ describe("Comment Routes", () => {
 
       const publicResponse = await app.inject({
         method: "GET",
-        url: `/api/posts/${post.id}/comments`,
+        url: `/posts/${post.id}/comments`,
       });
       expect(publicResponse.statusCode).toBe(200);
       expect(publicResponse.json().data[0].body).toBe(
@@ -393,7 +393,7 @@ describe("Comment Routes", () => {
 
       const revealResponse = await app.inject({
         method: "POST",
-        url: `/api/comments/${comment.id}/reveal`,
+        url: `/comments/${comment.id}/reveal`,
         payload: { revealToken },
       });
 
@@ -410,7 +410,7 @@ describe("Comment Routes", () => {
 
       const firstCreate = await app.inject({
         method: "POST",
-        url: `/api/posts/${post.id}/comments`,
+        url: `/posts/${post.id}/comments`,
         payload: {
           body: "첫 번째 비밀 댓글",
           guestName: "작성자1",
@@ -420,7 +420,7 @@ describe("Comment Routes", () => {
       });
       const secondCreate = await app.inject({
         method: "POST",
-        url: `/api/posts/${post.id}/comments`,
+        url: `/posts/${post.id}/comments`,
         payload: {
           body: "두 번째 비밀 댓글",
           guestName: "작성자2",
@@ -434,7 +434,7 @@ describe("Comment Routes", () => {
 
       const revealResponse = await app.inject({
         method: "POST",
-        url: `/api/comments/${second.data.id}/reveal`,
+        url: `/comments/${second.data.id}/reveal`,
         payload: { revealToken: first.revealToken },
       });
 
@@ -450,7 +450,7 @@ describe("Comment Routes", () => {
 
       const createResponse = await app.inject({
         method: "POST",
-        url: `/api/posts/${post.id}/comments`,
+        url: `/posts/${post.id}/comments`,
         payload: {
           body: "삭제될 비밀 댓글",
           guestName: "삭제자",
@@ -463,14 +463,14 @@ describe("Comment Routes", () => {
 
       const deleteResponse = await app.inject({
         method: "DELETE",
-        url: `/api/comments/${comment.id}`,
+        url: `/comments/${comment.id}`,
         payload: { guestPassword: "pass1234" },
       });
       expect(deleteResponse.statusCode).toBe(204);
 
       const revealResponse = await app.inject({
         method: "POST",
-        url: `/api/comments/${comment.id}/reveal`,
+        url: `/comments/${comment.id}/reveal`,
         payload: { revealToken },
       });
 
@@ -478,9 +478,9 @@ describe("Comment Routes", () => {
     });
   });
 
-  // ===== DELETE /api/comments/:id =====
+  // ===== DELETE /comments/:id =====
 
-  describe("DELETE /api/comments/:id", () => {
+  describe("DELETE /comments/:id", () => {
     it("게스트 댓글 삭제 (비밀번호) → 204", async () => {
       const category = await seedCategory();
       const post = await seedPost(category.id, {
@@ -491,7 +491,7 @@ describe("Comment Routes", () => {
       // 게스트 댓글 작성
       const createResponse = await app.inject({
         method: "POST",
-        url: `/api/posts/${post.id}/comments`,
+        url: `/posts/${post.id}/comments`,
         payload: {
           body: "삭제될 댓글",
           guestName: "삭제자",
@@ -504,7 +504,7 @@ describe("Comment Routes", () => {
       // 비밀번호로 삭제
       const deleteResponse = await app.inject({
         method: "DELETE",
-        url: `/api/comments/${comment.id}`,
+        url: `/comments/${comment.id}`,
         payload: { guestPassword: "mypassword123" },
       });
 
@@ -513,7 +513,7 @@ describe("Comment Routes", () => {
       // 삭제 후 목록에서 사라짐 확인
       const listResponse = await app.inject({
         method: "GET",
-        url: `/api/posts/${post.id}/comments`,
+        url: `/posts/${post.id}/comments`,
       });
       expect(listResponse.json().data).toHaveLength(0);
     });
@@ -534,7 +534,7 @@ describe("Comment Routes", () => {
       // User A가 댓글 작성
       const createResponse = await app.inject({
         method: "POST",
-        url: `/api/posts/${post.id}/comments`,
+        url: `/posts/${post.id}/comments`,
         headers: { cookie: cookieA },
         payload: { body: "User A의 댓글" },
       });
@@ -543,7 +543,7 @@ describe("Comment Routes", () => {
       // User B가 삭제 시도 → 403
       const deleteResponse = await app.inject({
         method: "DELETE",
-        url: `/api/comments/${comment.id}`,
+        url: `/comments/${comment.id}`,
         headers: { cookie: cookieB },
       });
 
@@ -551,13 +551,13 @@ describe("Comment Routes", () => {
     });
   });
 
-  // ===== GET /api/admin/comments =====
+  // ===== GET /admin/comments =====
 
-  describe("GET /api/admin/comments", () => {
+  describe("GET /admin/comments", () => {
     it("관리자 인증 없이 접근 → 403", async () => {
       const response = await app.inject({
         method: "GET",
-        url: "/api/admin/comments",
+        url: "/admin/comments",
       });
 
       expect(response.statusCode).toBe(403);
@@ -577,7 +577,7 @@ describe("Comment Routes", () => {
       // 댓글 2개 작성
       await app.inject({
         method: "POST",
-        url: `/api/posts/${post.id}/comments`,
+        url: `/posts/${post.id}/comments`,
         payload: {
           body: "첫 번째 댓글",
           guestName: "작성자1",
@@ -587,7 +587,7 @@ describe("Comment Routes", () => {
       });
       await app.inject({
         method: "POST",
-        url: `/api/posts/${post.id}/comments`,
+        url: `/posts/${post.id}/comments`,
         payload: {
           body: "두 번째 댓글",
           guestName: "작성자2",
@@ -598,7 +598,7 @@ describe("Comment Routes", () => {
 
       const response = await app.inject({
         method: "GET",
-        url: "/api/admin/comments",
+        url: "/admin/comments",
         headers: { cookie: adminCookie },
       });
 
@@ -625,7 +625,7 @@ describe("Comment Routes", () => {
 
       const createResponse = await app.inject({
         method: "POST",
-        url: `/api/posts/${post.id}/comments`,
+        url: `/posts/${post.id}/comments`,
         payload: {
           body: "삭제될 댓글",
           guestName: "작성자",
@@ -638,14 +638,14 @@ describe("Comment Routes", () => {
       // 댓글 soft delete
       await app.inject({
         method: "DELETE",
-        url: `/api/admin/comments/${comment.id}?action=soft_delete`,
+        url: `/admin/comments/${comment.id}?action=soft_delete`,
         headers: { cookie: adminCookie },
       });
 
       // status=active 필터 → 0개
       const activeResponse = await app.inject({
         method: "GET",
-        url: "/api/admin/comments?status=active",
+        url: "/admin/comments?status=active",
         headers: { cookie: adminCookie },
       });
       expect(activeResponse.json().data).toHaveLength(0);
@@ -653,7 +653,7 @@ describe("Comment Routes", () => {
       // status=deleted 필터 → 1개
       const deletedResponse = await app.inject({
         method: "GET",
-        url: "/api/admin/comments?status=deleted",
+        url: "/admin/comments?status=deleted",
         headers: { cookie: adminCookie },
       });
       expect(deletedResponse.json().data).toHaveLength(1);
@@ -675,7 +675,7 @@ describe("Comment Routes", () => {
 
       await app.inject({
         method: "POST",
-        url: `/api/posts/${post1.id}/comments`,
+        url: `/posts/${post1.id}/comments`,
         payload: {
           body: "post1 댓글",
           guestName: "작성자",
@@ -685,7 +685,7 @@ describe("Comment Routes", () => {
       });
       await app.inject({
         method: "POST",
-        url: `/api/posts/${post2.id}/comments`,
+        url: `/posts/${post2.id}/comments`,
         payload: {
           body: "post2 댓글",
           guestName: "작성자",
@@ -696,7 +696,7 @@ describe("Comment Routes", () => {
 
       const response = await app.inject({
         method: "GET",
-        url: `/api/admin/comments?postId=${post1.id}`,
+        url: `/admin/comments?postId=${post1.id}`,
         headers: { cookie: adminCookie },
       });
 
@@ -722,7 +722,7 @@ describe("Comment Routes", () => {
 
       await app.inject({
         method: "POST",
-        url: `/api/posts/${post.id}/comments`,
+        url: `/posts/${post.id}/comments`,
         headers: { cookie: userCookie },
         payload: {
           body: "비밀 내용 원문",
@@ -732,7 +732,7 @@ describe("Comment Routes", () => {
 
       const response = await app.inject({
         method: "GET",
-        url: "/api/admin/comments",
+        url: "/admin/comments",
         headers: { cookie: adminCookie },
       });
 
@@ -756,7 +756,7 @@ describe("Comment Routes", () => {
       // OAuth 댓글
       await app.inject({
         method: "POST",
-        url: `/api/posts/${post.id}/comments`,
+        url: `/posts/${post.id}/comments`,
         headers: { cookie: userCookie },
         payload: { body: "OAuth 댓글" },
       });
@@ -764,7 +764,7 @@ describe("Comment Routes", () => {
       // 게스트 댓글
       await app.inject({
         method: "POST",
-        url: `/api/posts/${post.id}/comments`,
+        url: `/posts/${post.id}/comments`,
         payload: {
           body: "게스트 댓글",
           guestName: "게스트",
@@ -776,7 +776,7 @@ describe("Comment Routes", () => {
       // authorType=guest 필터 → 1개 (게스트만)
       const guestResponse = await app.inject({
         method: "GET",
-        url: "/api/admin/comments?authorType=guest",
+        url: "/admin/comments?authorType=guest",
         headers: { cookie: adminCookie },
       });
       expect(guestResponse.statusCode).toBe(200);
@@ -787,7 +787,7 @@ describe("Comment Routes", () => {
       // authorType=oauth 필터 → 1개 (OAuth만)
       const oauthResponse = await app.inject({
         method: "GET",
-        url: "/api/admin/comments?authorType=oauth",
+        url: "/admin/comments?authorType=oauth",
         headers: { cookie: adminCookie },
       });
       expect(oauthResponse.statusCode).toBe(200);
@@ -823,12 +823,12 @@ describe("Comment Routes", () => {
 
       const descResponse = await app.inject({
         method: "GET",
-        url: "/api/admin/comments?order=desc",
+        url: "/admin/comments?order=desc",
         headers: { cookie: adminCookie },
       });
       const ascResponse = await app.inject({
         method: "GET",
-        url: "/api/admin/comments?order=asc",
+        url: "/admin/comments?order=asc",
         headers: { cookie: adminCookie },
       });
 
@@ -847,9 +847,9 @@ describe("Comment Routes", () => {
     });
   });
 
-  // ===== GET /api/admin/comments/:id/thread =====
+  // ===== GET /admin/comments/:id/thread =====
 
-  describe("GET /api/admin/comments/:id/thread", () => {
+  describe("GET /admin/comments/:id/thread", () => {
     it("루트 댓글 ID로 스레드 조회 → 부모 + 답글 반환", async () => {
       await seedAdmin();
       const adminCookie = await injectAuth(app);
@@ -863,7 +863,7 @@ describe("Comment Routes", () => {
       // 루트 댓글
       const rootResponse = await app.inject({
         method: "POST",
-        url: `/api/posts/${post.id}/comments`,
+        url: `/posts/${post.id}/comments`,
         payload: {
           body: "루트 댓글",
           guestName: "부모",
@@ -876,7 +876,7 @@ describe("Comment Routes", () => {
       // 답글 2개
       await app.inject({
         method: "POST",
-        url: `/api/posts/${post.id}/comments`,
+        url: `/posts/${post.id}/comments`,
         payload: {
           body: "답글 1",
           parentId: rootComment.id,
@@ -887,7 +887,7 @@ describe("Comment Routes", () => {
       });
       await app.inject({
         method: "POST",
-        url: `/api/posts/${post.id}/comments`,
+        url: `/posts/${post.id}/comments`,
         payload: {
           body: "답글 2",
           parentId: rootComment.id,
@@ -899,7 +899,7 @@ describe("Comment Routes", () => {
 
       const response = await app.inject({
         method: "GET",
-        url: `/api/admin/comments/${rootComment.id}/thread`,
+        url: `/admin/comments/${rootComment.id}/thread`,
         headers: { cookie: adminCookie },
       });
 
@@ -923,7 +923,7 @@ describe("Comment Routes", () => {
       // 루트 댓글
       const rootResponse = await app.inject({
         method: "POST",
-        url: `/api/posts/${post.id}/comments`,
+        url: `/posts/${post.id}/comments`,
         payload: {
           body: "루트 댓글",
           guestName: "부모",
@@ -936,7 +936,7 @@ describe("Comment Routes", () => {
       // 답글
       const replyResponse = await app.inject({
         method: "POST",
-        url: `/api/posts/${post.id}/comments`,
+        url: `/posts/${post.id}/comments`,
         payload: {
           body: "답글",
           parentId: rootComment.id,
@@ -950,7 +950,7 @@ describe("Comment Routes", () => {
       // 답글 ID로 스레드 조회 → parent.id는 루트 ID
       const response = await app.inject({
         method: "GET",
-        url: `/api/admin/comments/${replyComment.id}/thread`,
+        url: `/admin/comments/${replyComment.id}/thread`,
         headers: { cookie: adminCookie },
       });
 
@@ -966,7 +966,7 @@ describe("Comment Routes", () => {
 
       const response = await app.inject({
         method: "GET",
-        url: "/api/admin/comments/99999/thread",
+        url: "/admin/comments/99999/thread",
         headers: { cookie: adminCookie },
       });
 
@@ -974,16 +974,16 @@ describe("Comment Routes", () => {
     });
   });
 
-  // ===== PUT /api/admin/comments/:id/hide =====
+  // ===== PUT /admin/comments/:id/hide =====
 
-  describe("PUT /api/admin/comments/:id/hide", () => {
+  describe("PUT /admin/comments/:id/hide", () => {
     it("active 댓글 숨김 → 200 + hidden 전환", async () => {
       await seedAdmin();
       const adminCookie = await injectAuth(app);
       const csrfToken = (
         await app.inject({
           method: "GET",
-          url: "/api/auth/csrf-token",
+          url: "/auth/csrf-token",
           headers: { cookie: adminCookie },
         })
       ).json().token;
@@ -1001,7 +1001,7 @@ describe("Comment Routes", () => {
 
       const hideResponse = await app.inject({
         method: "PUT",
-        url: `/api/admin/comments/${comment.id}/hide`,
+        url: `/admin/comments/${comment.id}/hide`,
         headers: {
           cookie: adminCookie,
           "x-csrf-token": csrfToken,
@@ -1026,7 +1026,7 @@ describe("Comment Routes", () => {
       const csrfToken = (
         await app.inject({
           method: "GET",
-          url: "/api/auth/csrf-token",
+          url: "/auth/csrf-token",
           headers: { cookie: adminCookie },
         })
       ).json().token;
@@ -1045,7 +1045,7 @@ describe("Comment Routes", () => {
 
       const hideResponse = await app.inject({
         method: "PUT",
-        url: `/api/admin/comments/${comment.id}/hide`,
+        url: `/admin/comments/${comment.id}/hide`,
         headers: {
           cookie: adminCookie,
           "x-csrf-token": csrfToken,
@@ -1061,7 +1061,7 @@ describe("Comment Routes", () => {
       const csrfToken = (
         await app.inject({
           method: "GET",
-          url: "/api/auth/csrf-token",
+          url: "/auth/csrf-token",
           headers: { cookie: adminCookie },
         })
       ).json().token;
@@ -1085,7 +1085,7 @@ describe("Comment Routes", () => {
 
       const hideResponse = await app.inject({
         method: "PUT",
-        url: `/api/admin/comments/${rootComment.id}/hide`,
+        url: `/admin/comments/${rootComment.id}/hide`,
         headers: {
           cookie: adminCookie,
           "x-csrf-token": csrfToken,
@@ -1096,7 +1096,7 @@ describe("Comment Routes", () => {
 
       const publicResponse = await app.inject({
         method: "GET",
-        url: `/api/posts/${post.id}/comments`,
+        url: `/posts/${post.id}/comments`,
       });
 
       expect(publicResponse.statusCode).toBe(200);
@@ -1106,9 +1106,9 @@ describe("Comment Routes", () => {
     });
   });
 
-  // ===== PUT /api/admin/comments/:id/restore =====
+  // ===== PUT /admin/comments/:id/restore =====
 
-  describe("PUT /api/admin/comments/:id/restore", () => {
+  describe("PUT /admin/comments/:id/restore", () => {
     it("삭제된 댓글 복원 → 200 + success:true", async () => {
       await seedAdmin();
       const adminCookie = await injectAuth(app);
@@ -1122,7 +1122,7 @@ describe("Comment Routes", () => {
       // 댓글 작성 후 삭제
       const createResponse = await app.inject({
         method: "POST",
-        url: `/api/posts/${post.id}/comments`,
+        url: `/posts/${post.id}/comments`,
         payload: {
           body: "복원될 댓글",
           guestName: "작성자",
@@ -1134,14 +1134,14 @@ describe("Comment Routes", () => {
 
       await app.inject({
         method: "DELETE",
-        url: `/api/admin/comments/${comment.id}?action=soft_delete`,
+        url: `/admin/comments/${comment.id}?action=soft_delete`,
         headers: { cookie: adminCookie },
       });
 
       // 복원
       const restoreResponse = await app.inject({
         method: "PUT",
-        url: `/api/admin/comments/${comment.id}/restore`,
+        url: `/admin/comments/${comment.id}/restore`,
         headers: { cookie: adminCookie },
       });
 
@@ -1151,7 +1151,7 @@ describe("Comment Routes", () => {
       // active 상태로 복원됐는지 확인
       const listResponse = await app.inject({
         method: "GET",
-        url: "/api/admin/comments?status=active",
+        url: "/admin/comments?status=active",
         headers: { cookie: adminCookie },
       });
       expect(listResponse.json().data).toHaveLength(1);
@@ -1174,7 +1174,7 @@ describe("Comment Routes", () => {
 
       const restoreResponse = await app.inject({
         method: "PUT",
-        url: `/api/admin/comments/${comment.id}/restore`,
+        url: `/admin/comments/${comment.id}/restore`,
         headers: { cookie: adminCookie },
       });
 
@@ -1202,7 +1202,7 @@ describe("Comment Routes", () => {
 
       const createResponse = await app.inject({
         method: "POST",
-        url: `/api/posts/${post.id}/comments`,
+        url: `/posts/${post.id}/comments`,
         payload: {
           body: "활성 댓글",
           guestName: "작성자",
@@ -1214,7 +1214,7 @@ describe("Comment Routes", () => {
 
       const restoreResponse = await app.inject({
         method: "PUT",
-        url: `/api/admin/comments/${comment.id}/restore`,
+        url: `/admin/comments/${comment.id}/restore`,
         headers: { cookie: adminCookie },
       });
 
@@ -1222,9 +1222,9 @@ describe("Comment Routes", () => {
     });
   });
 
-  // ===== DELETE /api/admin/comments/:id =====
+  // ===== DELETE /admin/comments/:id =====
 
-  describe("DELETE /api/admin/comments/:id", () => {
+  describe("DELETE /admin/comments/:id", () => {
     it("soft_delete → 204, 관리자 목록에서 deleted 상태로 조회 가능", async () => {
       await seedAdmin();
       const adminCookie = await injectAuth(app);
@@ -1237,7 +1237,7 @@ describe("Comment Routes", () => {
 
       const createResponse = await app.inject({
         method: "POST",
-        url: `/api/posts/${post.id}/comments`,
+        url: `/posts/${post.id}/comments`,
         payload: {
           body: "소프트 삭제될 댓글",
           guestName: "작성자",
@@ -1249,7 +1249,7 @@ describe("Comment Routes", () => {
 
       const deleteResponse = await app.inject({
         method: "DELETE",
-        url: `/api/admin/comments/${comment.id}?action=soft_delete`,
+        url: `/admin/comments/${comment.id}?action=soft_delete`,
         headers: { cookie: adminCookie },
       });
 
@@ -1258,7 +1258,7 @@ describe("Comment Routes", () => {
       // 관리자 목록에서 deleted로 조회 가능
       const listResponse = await app.inject({
         method: "GET",
-        url: "/api/admin/comments?status=deleted",
+        url: "/admin/comments?status=deleted",
         headers: { cookie: adminCookie },
       });
       expect(listResponse.json().data).toHaveLength(1);
@@ -1276,7 +1276,7 @@ describe("Comment Routes", () => {
 
       const rootResponse = await app.inject({
         method: "POST",
-        url: `/api/posts/${post.id}/comments`,
+        url: `/posts/${post.id}/comments`,
         payload: {
           body: "루트 댓글",
           guestName: "부모",
@@ -1289,7 +1289,7 @@ describe("Comment Routes", () => {
       // 답글 작성
       await app.inject({
         method: "POST",
-        url: `/api/posts/${post.id}/comments`,
+        url: `/posts/${post.id}/comments`,
         payload: {
           body: "답글",
           parentId: rootComment.id,
@@ -1302,7 +1302,7 @@ describe("Comment Routes", () => {
       // hard_delete
       const deleteResponse = await app.inject({
         method: "DELETE",
-        url: `/api/admin/comments/${rootComment.id}?action=hard_delete`,
+        url: `/admin/comments/${rootComment.id}?action=hard_delete`,
         headers: { cookie: adminCookie },
       });
 
@@ -1311,7 +1311,7 @@ describe("Comment Routes", () => {
       // 관리자 목록에서도 사라짐 (hard delete)
       const listResponse = await app.inject({
         method: "GET",
-        url: "/api/admin/comments",
+        url: "/admin/comments",
         headers: { cookie: adminCookie },
       });
       expect(listResponse.json().data).toHaveLength(0);
@@ -1329,7 +1329,7 @@ describe("Comment Routes", () => {
 
       const createResponse = await app.inject({
         method: "POST",
-        url: `/api/posts/${post.id}/comments`,
+        url: `/posts/${post.id}/comments`,
         payload: {
           body: "관리자가 삭제할 댓글",
           guestName: "작성자",
@@ -1341,7 +1341,7 @@ describe("Comment Routes", () => {
 
       const deleteResponse = await app.inject({
         method: "DELETE",
-        url: `/api/admin/comments/${comment.id}`,
+        url: `/admin/comments/${comment.id}`,
         headers: { cookie: adminCookie },
       });
 
@@ -1349,16 +1349,16 @@ describe("Comment Routes", () => {
     });
   });
 
-  // ===== DELETE /api/admin/comments/bulk =====
+  // ===== DELETE /admin/comments/bulk =====
 
-  describe("DELETE /api/admin/comments/bulk", () => {
+  describe("DELETE /admin/comments/bulk", () => {
     it("벌크 hide → 204, active 상태만 hidden으로 전환", async () => {
       await seedAdmin();
       const adminCookie = await injectAuth(app);
       const csrfToken = (
         await app.inject({
           method: "GET",
-          url: "/api/auth/csrf-token",
+          url: "/auth/csrf-token",
           headers: { cookie: adminCookie },
         })
       ).json().token;
@@ -1381,7 +1381,7 @@ describe("Comment Routes", () => {
 
       const bulkResponse = await app.inject({
         method: "DELETE",
-        url: "/api/admin/comments/bulk",
+        url: "/admin/comments/bulk",
         headers: {
           cookie: adminCookie,
           "x-csrf-token": csrfToken,
@@ -1414,7 +1414,7 @@ describe("Comment Routes", () => {
       const csrfToken = (
         await app.inject({
           method: "GET",
-          url: "/api/auth/csrf-token",
+          url: "/auth/csrf-token",
           headers: { cookie: adminCookie },
         })
       ).json().token;
@@ -1429,7 +1429,7 @@ describe("Comment Routes", () => {
       for (let i = 1; i <= 3; i++) {
         const r = await app.inject({
           method: "POST",
-          url: `/api/posts/${post.id}/comments`,
+          url: `/posts/${post.id}/comments`,
           payload: {
             body: `댓글 ${i}`,
             guestName: `작성자${i}`,
@@ -1442,7 +1442,7 @@ describe("Comment Routes", () => {
 
       const bulkResponse = await app.inject({
         method: "DELETE",
-        url: "/api/admin/comments/bulk",
+        url: "/admin/comments/bulk",
         headers: {
           cookie: adminCookie,
           "x-csrf-token": csrfToken,
@@ -1454,7 +1454,7 @@ describe("Comment Routes", () => {
 
       const listResponse = await app.inject({
         method: "GET",
-        url: "/api/admin/comments?status=deleted",
+        url: "/admin/comments?status=deleted",
         headers: { cookie: adminCookie },
       });
       expect(listResponse.json().data).toHaveLength(3);
@@ -1466,7 +1466,7 @@ describe("Comment Routes", () => {
       const csrfToken = (
         await app.inject({
           method: "GET",
-          url: "/api/auth/csrf-token",
+          url: "/auth/csrf-token",
           headers: { cookie: adminCookie },
         })
       ).json().token;
@@ -1481,7 +1481,7 @@ describe("Comment Routes", () => {
       for (let i = 1; i <= 2; i++) {
         const r = await app.inject({
           method: "POST",
-          url: `/api/posts/${post.id}/comments`,
+          url: `/posts/${post.id}/comments`,
           payload: {
             body: `댓글 ${i}`,
             guestName: `작성자${i}`,
@@ -1495,7 +1495,7 @@ describe("Comment Routes", () => {
       // 먼저 soft_delete
       await app.inject({
         method: "DELETE",
-        url: "/api/admin/comments/bulk",
+        url: "/admin/comments/bulk",
         headers: {
           cookie: adminCookie,
           "x-csrf-token": csrfToken,
@@ -1506,7 +1506,7 @@ describe("Comment Routes", () => {
       // 복원
       const restoreResponse = await app.inject({
         method: "DELETE",
-        url: "/api/admin/comments/bulk",
+        url: "/admin/comments/bulk",
         headers: {
           cookie: adminCookie,
           "x-csrf-token": csrfToken,
@@ -1518,7 +1518,7 @@ describe("Comment Routes", () => {
 
       const listResponse = await app.inject({
         method: "GET",
-        url: "/api/admin/comments?status=active",
+        url: "/admin/comments?status=active",
         headers: { cookie: adminCookie },
       });
       expect(listResponse.json().data).toHaveLength(2);
@@ -1530,7 +1530,7 @@ describe("Comment Routes", () => {
       const csrfToken = (
         await app.inject({
           method: "GET",
-          url: "/api/auth/csrf-token",
+          url: "/auth/csrf-token",
           headers: { cookie: adminCookie },
         })
       ).json().token;
@@ -1553,7 +1553,7 @@ describe("Comment Routes", () => {
 
       const restoreResponse = await app.inject({
         method: "DELETE",
-        url: "/api/admin/comments/bulk",
+        url: "/admin/comments/bulk",
         headers: {
           cookie: adminCookie,
           "x-csrf-token": csrfToken,
@@ -1586,7 +1586,7 @@ describe("Comment Routes", () => {
       const csrfToken = (
         await app.inject({
           method: "GET",
-          url: "/api/auth/csrf-token",
+          url: "/auth/csrf-token",
           headers: { cookie: adminCookie },
         })
       ).json().token;
@@ -1599,7 +1599,7 @@ describe("Comment Routes", () => {
 
       const rootResponse = await app.inject({
         method: "POST",
-        url: `/api/posts/${post.id}/comments`,
+        url: `/posts/${post.id}/comments`,
         payload: {
           body: "루트 댓글",
           guestName: "부모",
@@ -1612,7 +1612,7 @@ describe("Comment Routes", () => {
       // 답글 추가
       await app.inject({
         method: "POST",
-        url: `/api/posts/${post.id}/comments`,
+        url: `/posts/${post.id}/comments`,
         payload: {
           body: "답글",
           parentId: rootComment.id,
@@ -1624,7 +1624,7 @@ describe("Comment Routes", () => {
 
       const bulkResponse = await app.inject({
         method: "DELETE",
-        url: "/api/admin/comments/bulk",
+        url: "/admin/comments/bulk",
         headers: {
           cookie: adminCookie,
           "x-csrf-token": csrfToken,
@@ -1637,7 +1637,7 @@ describe("Comment Routes", () => {
       // 루트 + 대댓글 모두 삭제됨
       const listResponse = await app.inject({
         method: "GET",
-        url: "/api/admin/comments",
+        url: "/admin/comments",
         headers: { cookie: adminCookie },
       });
       expect(listResponse.json().data).toHaveLength(0);

--- a/test/routes/csrf.e2e.test.ts
+++ b/test/routes/csrf.e2e.test.ts
@@ -59,14 +59,14 @@ describe("CSRF Route Wiring", () => {
   it("rejects guestbook creation when the issued session cookie is missing its CSRF token", async () => {
     const csrfResponse = await app.inject({
       method: "GET",
-      url: "/api/auth/csrf-token",
+      url: "/auth/csrf-token",
     });
 
     const sessionCookie = getSessionCookie(csrfResponse.headers["set-cookie"]);
 
     const response = await app.inject({
       method: "POST",
-      url: "/api/guestbook",
+      url: "/guestbook",
       headers: {
         cookie: sessionCookie,
       },
@@ -81,10 +81,10 @@ describe("CSRF Route Wiring", () => {
     expect(response.statusCode).toBe(403);
   });
 
-  it("accepts guestbook creation with the token and cookie issued by /api/auth/csrf-token", async () => {
+  it("accepts guestbook creation with the token and cookie issued by /auth/csrf-token", async () => {
     const csrfResponse = await app.inject({
       method: "GET",
-      url: "/api/auth/csrf-token",
+      url: "/auth/csrf-token",
     });
 
     const { token } = csrfResponse.json();
@@ -92,7 +92,7 @@ describe("CSRF Route Wiring", () => {
 
     const response = await app.inject({
       method: "POST",
-      url: "/api/guestbook",
+      url: "/guestbook",
       headers: {
         cookie: sessionCookie,
         "x-csrf-token": token,

--- a/test/routes/guestbook.test.ts
+++ b/test/routes/guestbook.test.ts
@@ -17,7 +17,7 @@ describe("Guestbook Routes", () => {
   async function getCsrfHeaders(cookie?: string): Promise<Record<string, string>> {
     const response = await app.inject({
       method: "GET",
-      url: "/api/auth/csrf-token",
+      url: "/auth/csrf-token",
       headers: cookie ? { cookie } : undefined,
     });
     const setCookie = response.headers["set-cookie"];
@@ -45,14 +45,14 @@ describe("Guestbook Routes", () => {
     await truncateAll();
   });
 
-  // ===== POST /api/guestbook =====
+  // ===== POST /guestbook =====
 
-  describe("POST /api/guestbook", () => {
+  describe("POST /guestbook", () => {
     it("게스트 방명록 작성 → 201", async () => {
       const csrfHeaders = await getCsrfHeaders();
       const response = await app.inject({
         method: "POST",
-        url: "/api/guestbook",
+        url: "/guestbook",
         headers: csrfHeaders,
         payload: {
           body: "안녕하세요! 방명록입니다.",
@@ -78,7 +78,7 @@ describe("Guestbook Routes", () => {
 
       const response = await app.inject({
         method: "POST",
-        url: "/api/guestbook",
+        url: "/guestbook",
         headers: csrfHeaders,
         payload: {
           body: "OAuth로 작성한 방명록입니다.",
@@ -101,7 +101,7 @@ describe("Guestbook Routes", () => {
       // 부모 방명록 작성
       const parentResponse = await app.inject({
         method: "POST",
-        url: "/api/guestbook",
+        url: "/guestbook",
         headers: parentHeaders,
         payload: {
           body: "부모 방명록",
@@ -117,7 +117,7 @@ describe("Guestbook Routes", () => {
       // 대댓글 작성
       const replyResponse = await app.inject({
         method: "POST",
-        url: "/api/guestbook",
+        url: "/guestbook",
         headers: replyHeaders,
         payload: {
           body: "대댓글 방명록",
@@ -135,16 +135,16 @@ describe("Guestbook Routes", () => {
     });
   });
 
-  // ===== GET /api/guestbook =====
+  // ===== GET /guestbook =====
 
-  describe("GET /api/guestbook", () => {
+  describe("GET /guestbook", () => {
     it("목록 조회 → 계층 구조 + 페이지네이션", async () => {
       const firstHeaders = await getCsrfHeaders();
 
       // 부모 방명록 2개 + 대댓글 1개 작성
       const p1Response = await app.inject({
         method: "POST",
-        url: "/api/guestbook",
+        url: "/guestbook",
         headers: firstHeaders,
         payload: {
           body: "첫 번째 방명록",
@@ -158,7 +158,7 @@ describe("Guestbook Routes", () => {
 
       await app.inject({
         method: "POST",
-        url: "/api/guestbook",
+        url: "/guestbook",
         headers: secondHeaders,
         payload: {
           body: "두 번째 방명록",
@@ -171,7 +171,7 @@ describe("Guestbook Routes", () => {
 
       await app.inject({
         method: "POST",
-        url: "/api/guestbook",
+        url: "/guestbook",
         headers: replyHeaders,
         payload: {
           body: "첫 번째 방명록의 대댓글",
@@ -185,7 +185,7 @@ describe("Guestbook Routes", () => {
       // limit=10으로 목록 조회 (child entry 포함하여 계층 구조 확인)
       const listResponse = await app.inject({
         method: "GET",
-        url: "/api/guestbook?page=1&limit=10",
+        url: "/guestbook?page=1&limit=10",
       });
 
       expect(listResponse.statusCode).toBe(200);
@@ -205,16 +205,16 @@ describe("Guestbook Routes", () => {
     });
   });
 
-  // ===== DELETE /api/guestbook/:id =====
+  // ===== DELETE /guestbook/:id =====
 
-  describe("DELETE /api/guestbook/:id", () => {
+  describe("DELETE /guestbook/:id", () => {
     it("게스트 삭제 (비밀번호) → 204", async () => {
       const createHeaders = await getCsrfHeaders();
 
       // 방명록 작성
       const createResponse = await app.inject({
         method: "POST",
-        url: "/api/guestbook",
+        url: "/guestbook",
         headers: createHeaders,
         payload: {
           body: "삭제될 방명록",
@@ -229,7 +229,7 @@ describe("Guestbook Routes", () => {
       // 비밀번호로 삭제
       const deleteResponse = await app.inject({
         method: "DELETE",
-        url: `/api/guestbook/${entry.id}`,
+        url: `/guestbook/${entry.id}`,
         headers: deleteHeaders,
         payload: { guestPassword: "deletepass123" },
       });
@@ -239,7 +239,7 @@ describe("Guestbook Routes", () => {
       // 삭제 후 목록에서 사라짐 확인
       const listResponse = await app.inject({
         method: "GET",
-        url: "/api/guestbook",
+        url: "/guestbook",
       });
       expect(listResponse.json().data).toHaveLength(0);
     });
@@ -256,7 +256,7 @@ describe("Guestbook Routes", () => {
       // User A가 방명록 작성
       const createResponse = await app.inject({
         method: "POST",
-        url: "/api/guestbook",
+        url: "/guestbook",
         headers: headersA,
         payload: { body: "User A의 방명록" },
       });
@@ -265,7 +265,7 @@ describe("Guestbook Routes", () => {
       // User B가 삭제 시도 → 403
       const deleteResponse = await app.inject({
         method: "DELETE",
-        url: `/api/guestbook/${entry.id}`,
+        url: `/guestbook/${entry.id}`,
         headers: headersB,
       });
 
@@ -273,13 +273,13 @@ describe("Guestbook Routes", () => {
     });
   });
 
-  // ===== GET /api/admin/guestbook =====
+  // ===== GET /admin/guestbook =====
 
-  describe("GET /api/admin/guestbook", () => {
+  describe("GET /admin/guestbook", () => {
     it("관리자 인증 없이 접근 → 403", async () => {
       const response = await app.inject({
         method: "GET",
-        url: "/api/admin/guestbook",
+        url: "/admin/guestbook",
       });
 
       expect(response.statusCode).toBe(403);
@@ -294,7 +294,7 @@ describe("Guestbook Routes", () => {
       // 방명록 2개 작성
       await app.inject({
         method: "POST",
-        url: "/api/guestbook",
+        url: "/guestbook",
         headers: firstHeaders,
         payload: {
           body: "첫 번째 방명록",
@@ -305,7 +305,7 @@ describe("Guestbook Routes", () => {
       });
       await app.inject({
         method: "POST",
-        url: "/api/guestbook",
+        url: "/guestbook",
         headers: secondHeaders,
         payload: {
           body: "두 번째 방명록",
@@ -317,7 +317,7 @@ describe("Guestbook Routes", () => {
 
       const response = await app.inject({
         method: "GET",
-        url: "/api/admin/guestbook",
+        url: "/admin/guestbook",
         headers: { cookie: adminCookie },
       });
 
@@ -341,7 +341,7 @@ describe("Guestbook Routes", () => {
       // OAuth 방명록
       await app.inject({
         method: "POST",
-        url: "/api/guestbook",
+        url: "/guestbook",
         headers: userHeaders,
         payload: { body: "OAuth 방명록" },
       });
@@ -349,7 +349,7 @@ describe("Guestbook Routes", () => {
       // Guest 방명록
       await app.inject({
         method: "POST",
-        url: "/api/guestbook",
+        url: "/guestbook",
         headers: guestHeaders,
         payload: {
           body: "게스트 방명록",
@@ -361,7 +361,7 @@ describe("Guestbook Routes", () => {
 
       const response = await app.inject({
         method: "GET",
-        url: "/api/admin/guestbook?authorType=guest",
+        url: "/admin/guestbook?authorType=guest",
         headers: { cookie: adminCookie },
       });
 
@@ -382,7 +382,7 @@ describe("Guestbook Routes", () => {
 
       await app.inject({
         method: "POST",
-        url: "/api/guestbook",
+        url: "/guestbook",
         headers: userHeaders,
         payload: {
           body: "비밀 방명록 원문",
@@ -392,7 +392,7 @@ describe("Guestbook Routes", () => {
 
       const response = await app.inject({
         method: "GET",
-        url: "/api/admin/guestbook",
+        url: "/admin/guestbook",
         headers: { cookie: adminCookie },
       });
 
@@ -401,9 +401,9 @@ describe("Guestbook Routes", () => {
     });
   });
 
-  // ===== DELETE /api/admin/guestbook/:id =====
+  // ===== DELETE /admin/guestbook/:id =====
 
-  describe("DELETE /api/admin/guestbook/:id", () => {
+  describe("DELETE /admin/guestbook/:id", () => {
     it("관리자 강제 삭제 → 204", async () => {
       await seedAdmin();
       const adminCookie = await injectAuth(app);
@@ -412,7 +412,7 @@ describe("Guestbook Routes", () => {
 
       const createResponse = await app.inject({
         method: "POST",
-        url: "/api/guestbook",
+        url: "/guestbook",
         headers: createHeaders,
         payload: {
           body: "관리자가 삭제할 방명록",
@@ -425,7 +425,7 @@ describe("Guestbook Routes", () => {
 
       const deleteResponse = await app.inject({
         method: "DELETE",
-        url: `/api/admin/guestbook/${entry.id}?action=soft_delete`,
+        url: `/admin/guestbook/${entry.id}?action=soft_delete`,
         headers: adminHeaders,
       });
 
@@ -433,9 +433,9 @@ describe("Guestbook Routes", () => {
     });
   });
 
-  // ===== PATCH /api/admin/guestbook/:id =====
+  // ===== PATCH /admin/guestbook/:id =====
 
-  describe("PATCH /api/admin/guestbook/:id", () => {
+  describe("PATCH /admin/guestbook/:id", () => {
     it("active 방명록 숨김 후 hidden 상태만 restore → 204", async () => {
       await seedAdmin();
       const adminCookie = await injectAuth(app);
@@ -444,7 +444,7 @@ describe("Guestbook Routes", () => {
 
       const createResponse = await app.inject({
         method: "POST",
-        url: "/api/guestbook",
+        url: "/guestbook",
         headers: createHeaders,
         payload: {
           body: "상태 변경 대상",
@@ -457,7 +457,7 @@ describe("Guestbook Routes", () => {
 
       const hideResponse = await app.inject({
         method: "PATCH",
-        url: `/api/admin/guestbook/${entry.id}?action=hide`,
+        url: `/admin/guestbook/${entry.id}?action=hide`,
         headers: adminHeaders,
       });
 
@@ -472,7 +472,7 @@ describe("Guestbook Routes", () => {
 
       const restoreResponse = await app.inject({
         method: "PATCH",
-        url: `/api/admin/guestbook/${entry.id}?action=restore`,
+        url: `/admin/guestbook/${entry.id}?action=restore`,
         headers: adminHeaders,
       });
 
@@ -487,9 +487,9 @@ describe("Guestbook Routes", () => {
     });
   });
 
-  // ===== DELETE /api/admin/guestbook/bulk =====
+  // ===== DELETE /admin/guestbook/bulk =====
 
-  describe("DELETE /api/admin/guestbook/bulk", () => {
+  describe("DELETE /admin/guestbook/bulk", () => {
     it("벌크 soft_delete → 204, deleted 상태로 전환", async () => {
       await seedAdmin();
       const adminCookie = await injectAuth(app);
@@ -499,7 +499,7 @@ describe("Guestbook Routes", () => {
 
       const firstResponse = await app.inject({
         method: "POST",
-        url: "/api/guestbook",
+        url: "/guestbook",
         headers: firstHeaders,
         payload: {
           body: "첫 번째 벌크 삭제",
@@ -510,7 +510,7 @@ describe("Guestbook Routes", () => {
       });
       const secondResponse = await app.inject({
         method: "POST",
-        url: "/api/guestbook",
+        url: "/guestbook",
         headers: secondHeaders,
         payload: {
           body: "두 번째 벌크 삭제",
@@ -523,7 +523,7 @@ describe("Guestbook Routes", () => {
       const ids = [firstResponse.json().data.id, secondResponse.json().data.id];
       const response = await app.inject({
         method: "DELETE",
-        url: "/api/admin/guestbook/bulk",
+        url: "/admin/guestbook/bulk",
         headers: adminHeaders,
         payload: { ids, action: "soft_delete" },
       });
@@ -540,9 +540,9 @@ describe("Guestbook Routes", () => {
     });
   });
 
-  // ===== PATCH /api/admin/guestbook/bulk =====
+  // ===== PATCH /admin/guestbook/bulk =====
 
-  describe("PATCH /api/admin/guestbook/bulk", () => {
+  describe("PATCH /admin/guestbook/bulk", () => {
     it("벌크 hide/restore → 상태 조건에 맞는 엔트리만 변경", async () => {
       await seedAdmin();
       const adminCookie = await injectAuth(app);
@@ -552,7 +552,7 @@ describe("Guestbook Routes", () => {
 
       const activeResponse = await app.inject({
         method: "POST",
-        url: "/api/guestbook",
+        url: "/guestbook",
         headers: firstHeaders,
         payload: {
           body: "active 엔트리",
@@ -563,7 +563,7 @@ describe("Guestbook Routes", () => {
       });
       const deletedResponse = await app.inject({
         method: "POST",
-        url: "/api/guestbook",
+        url: "/guestbook",
         headers: secondHeaders,
         payload: {
           body: "deleted 엔트리",
@@ -578,13 +578,13 @@ describe("Guestbook Routes", () => {
 
       await app.inject({
         method: "DELETE",
-        url: `/api/admin/guestbook/${deletedId}?action=soft_delete`,
+        url: `/admin/guestbook/${deletedId}?action=soft_delete`,
         headers: adminHeaders,
       });
 
       const hideResponse = await app.inject({
         method: "PATCH",
-        url: "/api/admin/guestbook/bulk",
+        url: "/admin/guestbook/bulk",
         headers: adminHeaders,
         payload: { ids: [activeId, deletedId], action: "hide" },
       });
@@ -601,7 +601,7 @@ describe("Guestbook Routes", () => {
 
       const restoreResponse = await app.inject({
         method: "PATCH",
-        url: "/api/admin/guestbook/bulk",
+        url: "/admin/guestbook/bulk",
         headers: adminHeaders,
         payload: { ids: [activeId, deletedId], action: "restore" },
       });

--- a/test/routes/health.test.ts
+++ b/test/routes/health.test.ts
@@ -56,10 +56,10 @@ describe("Health Routes", () => {
     expect(body.database.status).toBe("up");
   });
 
-  it("GET /health should include uptime and database status", async () => {
+  it("GET /health/status should include uptime and database status", async () => {
     const response = await app.inject({
       method: "GET",
-      url: "/health",
+      url: "/health/status",
     });
 
     const body = response.json();
@@ -87,12 +87,12 @@ describe("Health Routes", () => {
     expect(body.database.message).toBe("Database is unavailable");
   });
 
-  it("GET /health should return 503 when DB is down", async () => {
+  it("GET /health/status should return 503 when DB is down", async () => {
     vi.spyOn(app.db, "execute").mockRejectedValueOnce(new Error("db down"));
 
     const response = await app.inject({
       method: "GET",
-      url: "/health",
+      url: "/health/status",
     });
 
     const body = response.json();

--- a/test/routes/health.test.ts
+++ b/test/routes/health.test.ts
@@ -29,10 +29,10 @@ describe("Health Routes", () => {
     });
   });
 
-  it("GET /api/health/live should return liveness payload", async () => {
+  it("GET /health/live should return liveness payload", async () => {
     const response = await app.inject({
       method: "GET",
-      url: "/api/health/live",
+      url: "/health/live",
     });
 
     const body = response.json();
@@ -43,10 +43,10 @@ describe("Health Routes", () => {
     expect(typeof body.version).toBe("string");
   });
 
-  it("GET /api/health/ready should include database status", async () => {
+  it("GET /health/ready should include database status", async () => {
     const response = await app.inject({
       method: "GET",
-      url: "/api/health/ready",
+      url: "/health/ready",
     });
 
     const body = response.json();
@@ -56,10 +56,10 @@ describe("Health Routes", () => {
     expect(body.database.status).toBe("up");
   });
 
-  it("GET /api/health should include uptime and database status", async () => {
+  it("GET /health should include uptime and database status", async () => {
     const response = await app.inject({
       method: "GET",
-      url: "/api/health",
+      url: "/health",
     });
 
     const body = response.json();
@@ -71,12 +71,12 @@ describe("Health Routes", () => {
     expect(body.database.status).toBe("up");
   });
 
-  it("GET /api/health/ready should return 503 when DB is down", async () => {
+  it("GET /health/ready should return 503 when DB is down", async () => {
     vi.spyOn(app.db, "execute").mockRejectedValueOnce(new Error("db down"));
 
     const response = await app.inject({
       method: "GET",
-      url: "/api/health/ready",
+      url: "/health/ready",
     });
 
     const body = response.json();
@@ -87,12 +87,12 @@ describe("Health Routes", () => {
     expect(body.database.message).toBe("Database is unavailable");
   });
 
-  it("GET /api/health should return 503 when DB is down", async () => {
+  it("GET /health should return 503 when DB is down", async () => {
     vi.spyOn(app.db, "execute").mockRejectedValueOnce(new Error("db down"));
 
     const response = await app.inject({
       method: "GET",
-      url: "/api/health",
+      url: "/health",
     });
 
     const body = response.json();

--- a/test/routes/posts.test.ts
+++ b/test/routes/posts.test.ts
@@ -27,9 +27,9 @@ describe("Post Routes", () => {
     await truncateAll();
   });
 
-  // ===== POST /api/admin/posts =====
+  // ===== POST /admin/posts =====
 
-  describe("POST /api/admin/posts", () => {
+  describe("POST /admin/posts", () => {
     it("게시글 생성 성공 (태그 포함) → 201", async () => {
       await seedAdmin();
       const cookie = await injectAuth(app);
@@ -37,7 +37,7 @@ describe("Post Routes", () => {
 
       const response = await app.inject({
         method: "POST",
-        url: "/api/admin/posts",
+        url: "/admin/posts",
         headers: { cookie },
         payload: {
           title: "My First Post",
@@ -69,7 +69,7 @@ describe("Post Routes", () => {
 
       const response = await app.inject({
         method: "POST",
-        url: "/api/admin/posts",
+        url: "/admin/posts",
         headers: { cookie },
         payload: {
           title: "Post Without Thumbnail",
@@ -91,7 +91,7 @@ describe("Post Routes", () => {
 
       const response = await app.inject({
         method: "POST",
-        url: "/api/admin/posts",
+        url: "/admin/posts",
         headers: { cookie },
         payload: {
           title: "Invalid Thumbnail URL",
@@ -111,7 +111,7 @@ describe("Post Routes", () => {
 
       const response = await app.inject({
         method: "POST",
-        url: "/api/admin/posts",
+        url: "/admin/posts",
         headers: { cookie },
         payload: {
           contentMd: "# Hello",
@@ -125,7 +125,7 @@ describe("Post Routes", () => {
     it("비인증 → 403", async () => {
       const response = await app.inject({
         method: "POST",
-        url: "/api/admin/posts",
+        url: "/admin/posts",
         payload: {
           title: "My Post",
           contentMd: "# Hello",
@@ -143,7 +143,7 @@ describe("Post Routes", () => {
 
       const response = await app.inject({
         method: "POST",
-        url: "/api/admin/posts",
+        url: "/admin/posts",
         headers: { cookie },
         payload: {
           title: "Hello World Post",
@@ -164,7 +164,7 @@ describe("Post Routes", () => {
 
       const response = await app.inject({
         method: "POST",
-        url: "/api/admin/posts",
+        url: "/admin/posts",
         headers: { cookie },
         payload: {
           title: "한글 제목만 있는 글",
@@ -184,13 +184,13 @@ describe("Post Routes", () => {
 
       const first = await app.inject({
         method: "POST",
-        url: "/api/admin/posts",
+        url: "/admin/posts",
         headers: { cookie },
         payload: { title: "Duplicate Title", contentMd: "# A", categoryId: category.id },
       });
       const second = await app.inject({
         method: "POST",
-        url: "/api/admin/posts",
+        url: "/admin/posts",
         headers: { cookie },
         payload: { title: "Duplicate Title", contentMd: "# B", categoryId: category.id },
       });
@@ -210,7 +210,7 @@ describe("Post Routes", () => {
 
       const response = await app.inject({
         method: "POST",
-        url: "/api/admin/posts",
+        url: "/admin/posts",
         headers: { cookie },
         payload: {
           title: "!!!",
@@ -231,7 +231,7 @@ describe("Post Routes", () => {
 
       const existingNumericSlug = await app.inject({
         method: "POST",
-        url: "/api/admin/posts",
+        url: "/admin/posts",
         headers: { cookie },
         payload: {
           title: "2",
@@ -245,7 +245,7 @@ describe("Post Routes", () => {
 
       const response = await app.inject({
         method: "POST",
-        url: "/api/admin/posts",
+        url: "/admin/posts",
         headers: { cookie },
         payload: {
           title: "!!!",
@@ -267,7 +267,7 @@ describe("Post Routes", () => {
 
       const response = await app.inject({
         method: "POST",
-        url: "/api/admin/posts",
+        url: "/admin/posts",
         headers: { cookie },
         payload: {
           title: "Auto Publish",
@@ -289,7 +289,7 @@ describe("Post Routes", () => {
 
       const response = await app.inject({
         method: "POST",
-        url: "/api/admin/posts",
+        url: "/admin/posts",
         headers: { cookie },
         payload: {
           title: "Auto Summary",
@@ -313,7 +313,7 @@ describe("Post Routes", () => {
 
       const response = await app.inject({
         method: "POST",
-        url: "/api/admin/posts",
+        url: "/admin/posts",
         headers: { cookie },
         payload: {
           title: "Null Meta Post",
@@ -347,7 +347,7 @@ describe("Post Routes", () => {
 
       const response = await app.inject({
         method: "POST",
-        url: "/api/admin/posts",
+        url: "/admin/posts",
         headers: { cookie },
         payload: {
           title: "Overflow Pinned Post",
@@ -362,9 +362,9 @@ describe("Post Routes", () => {
     });
   });
 
-  // ===== GET /api/posts =====
+  // ===== GET /posts =====
 
-  describe("GET /api/posts", () => {
+  describe("GET /posts", () => {
     it("Public 목록 — published + public 게시글만 반환", async () => {
       const category = await seedCategory();
 
@@ -383,7 +383,7 @@ describe("Post Routes", () => {
 
       const response = await app.inject({
         method: "GET",
-        url: "/api/posts",
+        url: "/posts",
       });
 
       expect(response.statusCode).toBe(200);
@@ -408,7 +408,7 @@ describe("Post Routes", () => {
 
       const response = await app.inject({
         method: "GET",
-        url: "/api/posts?page=1&limit=2",
+        url: "/posts?page=1&limit=2",
       });
 
       expect(response.statusCode).toBe(200);
@@ -427,7 +427,7 @@ describe("Post Routes", () => {
 
       const response = await app.inject({
         method: "GET",
-        url: `/api/posts?categoryId=${cat1.id}`,
+        url: `/posts?categoryId=${cat1.id}`,
       });
 
       expect(response.statusCode).toBe(200);
@@ -455,7 +455,7 @@ describe("Post Routes", () => {
 
       const response = await app.inject({
         method: "GET",
-        url: "/api/posts?q=TypeScript",
+        url: "/posts?q=TypeScript",
       });
 
       expect(response.statusCode).toBe(200);
@@ -483,7 +483,7 @@ describe("Post Routes", () => {
 
       const response = await app.inject({
         method: "GET",
-        url: "/api/posts?q=Drizzle",
+        url: "/posts?q=Drizzle",
       });
 
       expect(response.statusCode).toBe(200);
@@ -512,7 +512,7 @@ describe("Post Routes", () => {
 
       const response = await app.inject({
         method: "GET",
-        url: `/api/posts?q=Fastify&categoryId=${cat1.id}`,
+        url: `/posts?q=Fastify&categoryId=${cat1.id}`,
       });
 
       expect(response.statusCode).toBe(200);
@@ -530,7 +530,7 @@ describe("Post Routes", () => {
 
       await app.inject({
         method: "POST",
-        url: "/api/admin/posts",
+        url: "/admin/posts",
         headers: { cookie },
         payload: {
           title: "TypeScript Post",
@@ -544,7 +544,7 @@ describe("Post Routes", () => {
 
       await app.inject({
         method: "POST",
-        url: "/api/admin/posts",
+        url: "/admin/posts",
         headers: { cookie },
         payload: {
           title: "React Post",
@@ -558,7 +558,7 @@ describe("Post Routes", () => {
 
       const response = await app.inject({
         method: "GET",
-        url: "/api/posts?tagSlug=typescript",
+        url: "/posts?tagSlug=typescript",
       });
 
       expect(response.statusCode).toBe(200);
@@ -572,9 +572,9 @@ describe("Post Routes", () => {
     });
   });
 
-  // ===== GET /api/posts/:slug =====
+  // ===== GET /posts/:slug =====
 
-  describe("GET /api/posts/:slug", () => {
+  describe("GET /posts/:slug", () => {
     it("상세 조회 + 이전/다음 네비게이션", async () => {
       const category = await seedCategory();
       const now = Date.now();
@@ -600,7 +600,7 @@ describe("Post Routes", () => {
 
       const response = await app.inject({
         method: "GET",
-        url: `/api/posts/${current.slug}`,
+        url: `/posts/${current.slug}`,
       });
 
       expect(response.statusCode).toBe(200);
@@ -616,16 +616,16 @@ describe("Post Routes", () => {
     it("존재하지 않는 slug → 404", async () => {
       const response = await app.inject({
         method: "GET",
-        url: "/api/posts/not-existing-slug",
+        url: "/posts/not-existing-slug",
       });
 
       expect(response.statusCode).toBe(404);
     });
   });
 
-  // ===== PATCH /api/admin/posts/:id =====
+  // ===== PATCH /admin/posts/:id =====
 
-  describe("PATCH /api/admin/posts/:id", () => {
+  describe("PATCH /admin/posts/:id", () => {
     it("수정 성공 (태그 변경 포함) → 200", async () => {
       await seedAdmin();
       const cookie = await injectAuth(app);
@@ -637,7 +637,7 @@ describe("Post Routes", () => {
 
       const response = await app.inject({
         method: "PATCH",
-        url: `/api/admin/posts/${post.id}`,
+        url: `/admin/posts/${post.id}`,
         headers: { cookie },
         payload: {
           title: "Updated Title",
@@ -663,7 +663,7 @@ describe("Post Routes", () => {
 
       const response = await app.inject({
         method: "PATCH",
-        url: `/api/admin/posts/${post.id}`,
+        url: `/admin/posts/${post.id}`,
         headers: { cookie },
         payload: { contentMd: "# Updated Content" },
       });
@@ -686,7 +686,7 @@ describe("Post Routes", () => {
 
       const response = await app.inject({
         method: "PATCH",
-        url: `/api/admin/posts/${post.id}`,
+        url: `/admin/posts/${post.id}`,
         headers: { cookie },
         payload: { status: "published" },
       });
@@ -710,7 +710,7 @@ describe("Post Routes", () => {
 
       const response = await app.inject({
         method: "PATCH",
-        url: `/api/admin/posts/${post.id}`,
+        url: `/admin/posts/${post.id}`,
         headers: { cookie },
         payload: { summary: null },
       });
@@ -728,7 +728,7 @@ describe("Post Routes", () => {
       // 태그가 있는 게시글 생성
       const createRes = await app.inject({
         method: "POST",
-        url: "/api/admin/posts",
+        url: "/admin/posts",
         headers: { cookie },
         payload: {
           title: "Tagged Post",
@@ -741,7 +741,7 @@ describe("Post Routes", () => {
 
       const response = await app.inject({
         method: "PATCH",
-        url: `/api/admin/posts/${postId}`,
+        url: `/admin/posts/${postId}`,
         headers: { cookie },
         payload: { tags: [] },
       });
@@ -756,7 +756,7 @@ describe("Post Routes", () => {
 
       const response = await app.inject({
         method: "PATCH",
-        url: "/api/admin/posts/99999",
+        url: "/admin/posts/99999",
         headers: { cookie },
         payload: { title: "Nope" },
       });
@@ -767,7 +767,7 @@ describe("Post Routes", () => {
     it("비인증 → 403", async () => {
       const response = await app.inject({
         method: "PATCH",
-        url: "/api/admin/posts/1",
+        url: "/admin/posts/1",
         payload: { title: "Nope" },
       });
 
@@ -790,7 +790,7 @@ describe("Post Routes", () => {
 
       const response = await app.inject({
         method: "PATCH",
-        url: `/api/admin/posts/${pinnedPost.id}`,
+        url: `/admin/posts/${pinnedPost.id}`,
         headers: { cookie },
         payload: { title: "Pinned Title Updated", isPinned: true },
       });
@@ -820,7 +820,7 @@ describe("Post Routes", () => {
 
       const response = await app.inject({
         method: "PATCH",
-        url: `/api/admin/posts/${targetPost.id}`,
+        url: `/admin/posts/${targetPost.id}`,
         headers: { cookie },
         payload: { isPinned: true },
       });
@@ -840,7 +840,7 @@ describe("Post Routes", () => {
 
       const response = await app.inject({
         method: "PATCH",
-        url: `/api/admin/posts/${post.id}`,
+        url: `/admin/posts/${post.id}`,
         headers: { cookie },
         payload: { title: "복구된 제목" },
       });
@@ -860,7 +860,7 @@ describe("Post Routes", () => {
 
       const response = await app.inject({
         method: "PATCH",
-        url: `/api/admin/posts/${post.id}`,
+        url: `/admin/posts/${post.id}`,
         headers: { cookie },
         payload: { title: "복구된 제목" },
       });
@@ -870,9 +870,9 @@ describe("Post Routes", () => {
     });
   });
 
-  // ===== GET /api/admin/posts/:id =====
+  // ===== GET /admin/posts/:id =====
 
-  describe("GET /api/admin/posts/:id", () => {
+  describe("GET /admin/posts/:id", () => {
     it("상세 조회 성공 — contentMd 포함 PostDetail 반환 → 200", async () => {
       await seedAdmin();
       const cookie = await injectAuth(app);
@@ -884,7 +884,7 @@ describe("Post Routes", () => {
 
       const response = await app.inject({
         method: "GET",
-        url: `/api/admin/posts/${post.id}`,
+        url: `/admin/posts/${post.id}`,
         headers: { cookie },
       });
 
@@ -905,7 +905,7 @@ describe("Post Routes", () => {
 
       const response = await app.inject({
         method: "GET",
-        url: `/api/admin/posts/${post.id}`,
+        url: `/admin/posts/${post.id}`,
         headers: { cookie },
       });
 
@@ -922,7 +922,7 @@ describe("Post Routes", () => {
 
       const response = await app.inject({
         method: "GET",
-        url: "/api/admin/posts/99999",
+        url: "/admin/posts/99999",
         headers: { cookie },
       });
 
@@ -932,16 +932,16 @@ describe("Post Routes", () => {
     it("비인증 → 403", async () => {
       const response = await app.inject({
         method: "GET",
-        url: "/api/admin/posts/1",
+        url: "/admin/posts/1",
       });
 
       expect(response.statusCode).toBe(403);
     });
   });
 
-  // ===== DELETE /api/admin/posts/:id =====
+  // ===== DELETE /admin/posts/:id =====
 
-  describe("DELETE /api/admin/posts/:id", () => {
+  describe("DELETE /admin/posts/:id", () => {
     it("Soft Delete → 204", async () => {
       await seedAdmin();
       const cookie = await injectAuth(app);
@@ -950,14 +950,14 @@ describe("Post Routes", () => {
 
       const response = await app.inject({
         method: "DELETE",
-        url: `/api/admin/posts/${post.id}`,
+        url: `/admin/posts/${post.id}`,
         headers: { cookie },
       });
 
       expect(response.statusCode).toBe(204);
     });
 
-    it("Soft Delete된 글 → Public GET /api/posts/:slug → 404", async () => {
+    it("Soft Delete된 글 → Public GET /posts/:slug → 404", async () => {
       await seedAdmin();
       const cookie = await injectAuth(app);
       const category = await seedCategory();
@@ -969,23 +969,23 @@ describe("Post Routes", () => {
       // Soft Delete
       await app.inject({
         method: "DELETE",
-        url: `/api/admin/posts/${post.id}`,
+        url: `/admin/posts/${post.id}`,
         headers: { cookie },
       });
 
       // Public 조회 → 404
       const response = await app.inject({
         method: "GET",
-        url: `/api/posts/${post.slug}`,
+        url: `/posts/${post.slug}`,
       });
 
       expect(response.statusCode).toBe(404);
     });
   });
 
-  // ===== GET /api/admin/posts =====
+  // ===== GET /admin/posts =====
 
-  describe("GET /api/admin/posts", () => {
+  describe("GET /admin/posts", () => {
     it("Admin은 모든 상태 게시글 조회 가능", async () => {
       await seedAdmin();
       const cookie = await injectAuth(app);
@@ -1003,7 +1003,7 @@ describe("Post Routes", () => {
 
       const response = await app.inject({
         method: "GET",
-        url: "/api/admin/posts",
+        url: "/admin/posts",
         headers: { cookie },
       });
 
@@ -1024,7 +1024,7 @@ describe("Post Routes", () => {
 
       const response = await app.inject({
         method: "GET",
-        url: "/api/admin/posts?status=draft",
+        url: "/admin/posts?status=draft",
         headers: { cookie },
       });
 
@@ -1044,7 +1044,7 @@ describe("Post Routes", () => {
 
       const response = await app.inject({
         method: "GET",
-        url: "/api/admin/posts?visibility=private",
+        url: "/admin/posts?visibility=private",
         headers: { cookie },
       });
 
@@ -1063,18 +1063,18 @@ describe("Post Routes", () => {
       // soft delete
       await app.inject({
         method: "DELETE",
-        url: `/api/admin/posts/${post.id}`,
+        url: `/admin/posts/${post.id}`,
         headers: { cookie },
       });
 
       const withoutDeleted = await app.inject({
         method: "GET",
-        url: "/api/admin/posts",
+        url: "/admin/posts",
         headers: { cookie },
       });
       const withDeleted = await app.inject({
         method: "GET",
-        url: "/api/admin/posts?includeDeleted=true",
+        url: "/admin/posts?includeDeleted=true",
         headers: { cookie },
       });
 
@@ -1094,13 +1094,13 @@ describe("Post Routes", () => {
       const deletedPost = await seedPost(category.id);
       await app.inject({
         method: "DELETE",
-        url: `/api/admin/posts/${deletedPost.id}`,
+        url: `/admin/posts/${deletedPost.id}`,
         headers: { cookie },
       });
 
       const response = await app.inject({
         method: "GET",
-        url: "/api/admin/posts?includeDeleted=false",
+        url: "/admin/posts?includeDeleted=false",
         headers: { cookie },
       });
 
@@ -1121,7 +1121,7 @@ describe("Post Routes", () => {
 
       const response = await app.inject({
         method: "GET",
-        url: "/api/admin/posts?limit=2&page=1",
+        url: "/admin/posts?limit=2&page=1",
         headers: { cookie },
       });
 
@@ -1150,7 +1150,7 @@ describe("Post Routes", () => {
 
       const response = await app.inject({
         method: "GET",
-        url: "/api/admin/posts?sort=totalPageviews&order=desc",
+        url: "/admin/posts?sort=totalPageviews&order=desc",
         headers: { cookie },
       });
 
@@ -1181,7 +1181,7 @@ describe("Post Routes", () => {
 
       const response = await app.inject({
         method: "GET",
-        url: "/api/admin/posts?sort=totalPageviews&order=asc",
+        url: "/admin/posts?sort=totalPageviews&order=asc",
         headers: { cookie },
       });
 
@@ -1212,7 +1212,7 @@ describe("Post Routes", () => {
 
       const response = await app.inject({
         method: "GET",
-        url: "/api/admin/posts?sort=commentCount&order=desc",
+        url: "/admin/posts?sort=commentCount&order=desc",
         headers: { cookie },
       });
 
@@ -1255,7 +1255,7 @@ describe("Post Routes", () => {
 
       const response = await app.inject({
         method: "GET",
-        url: "/api/admin/posts?status=published&sort=commentCount&order=asc&limit=2&page=2",
+        url: "/admin/posts?status=published&sort=commentCount&order=asc&limit=2&page=2",
         headers: { cookie },
       });
 
@@ -1272,16 +1272,16 @@ describe("Post Routes", () => {
     it("비인증 → 403", async () => {
       const response = await app.inject({
         method: "GET",
-        url: "/api/admin/posts",
+        url: "/admin/posts",
       });
 
       expect(response.statusCode).toBe(403);
     });
   });
 
-  // ===== GET /api/admin/posts/pinned-count =====
+  // ===== GET /admin/posts/pinned-count =====
 
-  describe("GET /api/admin/posts/pinned-count", () => {
+  describe("GET /admin/posts/pinned-count", () => {
     it("삭제된 글을 제외한 pinned 수를 반환", async () => {
       await seedAdmin();
       const cookie = await injectAuth(app);
@@ -1297,7 +1297,7 @@ describe("Post Routes", () => {
 
       const response = await app.inject({
         method: "GET",
-        url: "/api/admin/posts/pinned-count",
+        url: "/admin/posts/pinned-count",
         headers: { cookie },
       });
 
@@ -1308,16 +1308,16 @@ describe("Post Routes", () => {
     it("비인증 → 403", async () => {
       const response = await app.inject({
         method: "GET",
-        url: "/api/admin/posts/pinned-count",
+        url: "/admin/posts/pinned-count",
       });
 
       expect(response.statusCode).toBe(403);
     });
   });
 
-  // ===== GET /api/posts/slugs =====
+  // ===== GET /posts/slugs =====
 
-  describe("GET /api/posts/slugs", () => {
+  describe("GET /posts/slugs", () => {
     it("발행된 공개 글의 slug + updatedAt 반환", async () => {
       const category = await seedCategory();
 
@@ -1335,7 +1335,7 @@ describe("Post Routes", () => {
 
       const response = await app.inject({
         method: "GET",
-        url: "/api/posts/slugs",
+        url: "/posts/slugs",
       });
 
       expect(response.statusCode).toBe(200);
@@ -1349,7 +1349,7 @@ describe("Post Routes", () => {
     it("발행된 글이 없으면 빈 배열 반환", async () => {
       const response = await app.inject({
         method: "GET",
-        url: "/api/posts/slugs",
+        url: "/posts/slugs",
       });
 
       expect(response.statusCode).toBe(200);
@@ -1358,9 +1358,9 @@ describe("Post Routes", () => {
     });
   });
 
-  // ===== GET /api/posts - filter param =====
+  // ===== GET /posts - filter param =====
 
-  describe("GET /api/posts - filter 파라미터 (tag/category/comment)", () => {
+  describe("GET /posts - filter 파라미터 (tag/category/comment)", () => {
     it("filter=tag 로 태그 이름 검색", async () => {
       await seedAdmin();
       const cookie = await injectAuth(app);
@@ -1368,7 +1368,7 @@ describe("Post Routes", () => {
 
       await app.inject({
         method: "POST",
-        url: "/api/admin/posts",
+        url: "/admin/posts",
         headers: { cookie },
         payload: {
           title: "Post with Drizzle tag",
@@ -1381,7 +1381,7 @@ describe("Post Routes", () => {
       });
       await app.inject({
         method: "POST",
-        url: "/api/admin/posts",
+        url: "/admin/posts",
         headers: { cookie },
         payload: {
           title: "Post with React tag",
@@ -1395,7 +1395,7 @@ describe("Post Routes", () => {
 
       const response = await app.inject({
         method: "GET",
-        url: "/api/posts?q=drizzle&filter=tag",
+        url: "/posts?q=drizzle&filter=tag",
       });
 
       expect(response.statusCode).toBe(200);
@@ -1410,7 +1410,7 @@ describe("Post Routes", () => {
 
       const response = await app.inject({
         method: "GET",
-        url: "/api/posts?q=nonexistenttag&filter=tag",
+        url: "/posts?q=nonexistenttag&filter=tag",
       });
 
       expect(response.statusCode).toBe(200);
@@ -1426,7 +1426,7 @@ describe("Post Routes", () => {
 
       const response = await app.inject({
         method: "GET",
-        url: "/api/posts?q=Backend&filter=category",
+        url: "/posts?q=Backend&filter=category",
       });
 
       expect(response.statusCode).toBe(200);
@@ -1441,7 +1441,7 @@ describe("Post Routes", () => {
 
       const response = await app.inject({
         method: "GET",
-        url: "/api/posts?q=NonExistentCategory&filter=category",
+        url: "/posts?q=NonExistentCategory&filter=category",
       });
 
       expect(response.statusCode).toBe(200);
@@ -1464,7 +1464,7 @@ describe("Post Routes", () => {
       // postA에 "unique keyword" 포함 댓글 추가
       await app.inject({
         method: "POST",
-        url: `/api/posts/${postA.id}/comments`,
+        url: `/posts/${postA.id}/comments`,
         payload: {
           body: "This is a unique keyword comment",
           guestName: "Tester",
@@ -1475,7 +1475,7 @@ describe("Post Routes", () => {
       // postB에는 다른 댓글
       await app.inject({
         method: "POST",
-        url: `/api/posts/${postB.id}/comments`,
+        url: `/posts/${postB.id}/comments`,
         payload: {
           body: "Different comment here",
           guestName: "Tester",
@@ -1486,7 +1486,7 @@ describe("Post Routes", () => {
 
       const response = await app.inject({
         method: "GET",
-        url: "/api/posts?q=unique+keyword&filter=comment",
+        url: "/posts?q=unique+keyword&filter=comment",
       });
 
       expect(response.statusCode).toBe(200);
@@ -1501,7 +1501,7 @@ describe("Post Routes", () => {
 
       const response = await app.inject({
         method: "GET",
-        url: "/api/posts?q=nomatchcomment&filter=comment",
+        url: "/posts?q=nomatchcomment&filter=comment",
       });
 
       expect(response.statusCode).toBe(200);
@@ -1509,7 +1509,7 @@ describe("Post Routes", () => {
     });
   });
 
-  describe("GET /api/posts - filter 파라미터", () => {
+  describe("GET /posts - filter 파라미터", () => {
     it("filter=title 로 제목에서만 검색", async () => {
       const category = await seedCategory();
 
@@ -1528,7 +1528,7 @@ describe("Post Routes", () => {
 
       const response = await app.inject({
         method: "GET",
-        url: "/api/posts?q=Drizzle&filter=title",
+        url: "/posts?q=Drizzle&filter=title",
       });
 
       expect(response.statusCode).toBe(200);
@@ -1556,7 +1556,7 @@ describe("Post Routes", () => {
 
       const response = await app.inject({
         method: "GET",
-        url: "/api/posts?q=Fastify&filter=content",
+        url: "/posts?q=Fastify&filter=content",
       });
 
       expect(response.statusCode).toBe(200);
@@ -1569,7 +1569,7 @@ describe("Post Routes", () => {
 
   // ===== PostDetail schema - category.ancestors =====
 
-  describe("GET /api/posts/:slug - category ancestors", () => {
+  describe("GET /posts/:slug - category ancestors", () => {
     it("중첩 카테고리의 ancestors 반환", async () => {
       await seedAdmin();
       const cookie = await injectAuth(app);
@@ -1579,7 +1579,7 @@ describe("Post Routes", () => {
 
       const createRes = await app.inject({
         method: "POST",
-        url: "/api/admin/posts",
+        url: "/admin/posts",
         headers: { cookie },
         payload: {
           title: "TypeScript Tips",
@@ -1594,7 +1594,7 @@ describe("Post Routes", () => {
 
       const response = await app.inject({
         method: "GET",
-        url: `/api/posts/${post.slug}`,
+        url: `/posts/${post.slug}`,
       });
 
       expect(response.statusCode).toBe(200);
@@ -1608,7 +1608,7 @@ describe("Post Routes", () => {
 
   // ===== PostListItem schema - totalPageviews and commentCount =====
 
-  describe("GET /api/posts - totalPageviews and commentCount in response", () => {
+  describe("GET /posts - totalPageviews and commentCount in response", () => {
     it("목록 응답에 totalPageviews와 commentCount 포함", async () => {
       const category = await seedCategory();
 
@@ -1619,7 +1619,7 @@ describe("Post Routes", () => {
 
       const response = await app.inject({
         method: "GET",
-        url: "/api/posts",
+        url: "/posts",
       });
 
       expect(response.statusCode).toBe(200);
@@ -1652,7 +1652,7 @@ describe("Post Routes", () => {
 
       const listResponse = await app.inject({
         method: "GET",
-        url: "/api/posts",
+        url: "/posts",
       });
 
       expect(listResponse.statusCode).toBe(200);
@@ -1660,7 +1660,7 @@ describe("Post Routes", () => {
 
       const detailResponse = await app.inject({
         method: "GET",
-        url: `/api/posts/${post.slug}`,
+        url: `/posts/${post.slug}`,
       });
 
       expect(detailResponse.statusCode).toBe(200);
@@ -1668,7 +1668,7 @@ describe("Post Routes", () => {
 
       const searchResponse = await app.inject({
         method: "GET",
-        url: "/api/posts?q=hidden-thread-keyword&filter=comment",
+        url: "/posts?q=hidden-thread-keyword&filter=comment",
       });
 
       expect(searchResponse.statusCode).toBe(200);
@@ -1676,9 +1676,9 @@ describe("Post Routes", () => {
     });
   });
 
-  // ===== DELETE /api/admin/posts/:id/hard =====
+  // ===== DELETE /admin/posts/:id/hard =====
 
-  describe("DELETE /api/admin/posts/:id/hard", () => {
+  describe("DELETE /admin/posts/:id/hard", () => {
     it("Hard Delete → 204, 게시글 영구 삭제", async () => {
       await seedAdmin();
       const cookie = await injectAuth(app);
@@ -1687,7 +1687,7 @@ describe("Post Routes", () => {
 
       const response = await app.inject({
         method: "DELETE",
-        url: `/api/admin/posts/${post.id}/hard`,
+        url: `/admin/posts/${post.id}/hard`,
         headers: { cookie },
       });
 
@@ -1696,7 +1696,7 @@ describe("Post Routes", () => {
       // Admin GET → 404
       const getResponse = await app.inject({
         method: "GET",
-        url: `/api/admin/posts/${post.id}`,
+        url: `/admin/posts/${post.id}`,
         headers: { cookie },
       });
       expect(getResponse.statusCode).toBe(404);
@@ -1710,7 +1710,7 @@ describe("Post Routes", () => {
       // 태그 있는 게시글 생성
       const createRes = await app.inject({
         method: "POST",
-        url: "/api/admin/posts",
+        url: "/admin/posts",
         headers: { cookie },
         payload: {
           title: "Tagged Post",
@@ -1724,7 +1724,7 @@ describe("Post Routes", () => {
       // Hard Delete
       const response = await app.inject({
         method: "DELETE",
-        url: `/api/admin/posts/${postId}/hard`,
+        url: `/admin/posts/${postId}/hard`,
         headers: { cookie },
       });
       expect(response.statusCode).toBe(204);
@@ -1745,7 +1745,7 @@ describe("Post Routes", () => {
       // 두 게시글에 같은 태그
       const res1 = await app.inject({
         method: "POST",
-        url: "/api/admin/posts",
+        url: "/admin/posts",
         headers: { cookie },
         payload: {
           title: "Post 1",
@@ -1756,7 +1756,7 @@ describe("Post Routes", () => {
       });
       await app.inject({
         method: "POST",
-        url: "/api/admin/posts",
+        url: "/admin/posts",
         headers: { cookie },
         payload: {
           title: "Post 2",
@@ -1770,7 +1770,7 @@ describe("Post Routes", () => {
       // 첫 번째 게시글 Hard Delete
       const response = await app.inject({
         method: "DELETE",
-        url: `/api/admin/posts/${postId}/hard`,
+        url: `/admin/posts/${postId}/hard`,
         headers: { cookie },
       });
       expect(response.statusCode).toBe(204);
@@ -1789,16 +1789,16 @@ describe("Post Routes", () => {
 
       const response = await app.inject({
         method: "DELETE",
-        url: "/api/admin/posts/99999/hard",
+        url: "/admin/posts/99999/hard",
         headers: { cookie },
       });
       expect(response.statusCode).toBe(404);
     });
   });
 
-  // ===== PUT /api/admin/posts/:id/restore =====
+  // ===== PUT /admin/posts/:id/restore =====
 
-  describe("PUT /api/admin/posts/:id/restore", () => {
+  describe("PUT /admin/posts/:id/restore", () => {
     it("복원 성공 → 200, deletedAt이 null", async () => {
       await seedAdmin();
       const cookie = await injectAuth(app);
@@ -1808,14 +1808,14 @@ describe("Post Routes", () => {
       // Soft Delete
       await app.inject({
         method: "DELETE",
-        url: `/api/admin/posts/${post.id}`,
+        url: `/admin/posts/${post.id}`,
         headers: { cookie },
       });
 
       // Restore
       const response = await app.inject({
         method: "PUT",
-        url: `/api/admin/posts/${post.id}/restore`,
+        url: `/admin/posts/${post.id}/restore`,
         headers: { cookie },
       });
 
@@ -1844,7 +1844,7 @@ describe("Post Routes", () => {
 
       const response = await app.inject({
         method: "PUT",
-        url: `/api/admin/posts/${deletedPinnedPost.id}/restore`,
+        url: `/admin/posts/${deletedPinnedPost.id}/restore`,
         headers: { cookie },
       });
 
@@ -1853,9 +1853,9 @@ describe("Post Routes", () => {
     });
   });
 
-  // ===== PATCH /api/admin/posts/bulk =====
+  // ===== PATCH /admin/posts/bulk =====
 
-  describe("PATCH /api/admin/posts/bulk", () => {
+  describe("PATCH /admin/posts/bulk", () => {
     it("action=update: categoryId 일괄 변경 → 204", async () => {
       await seedAdmin();
       const cookie = await injectAuth(app);
@@ -1867,7 +1867,7 @@ describe("Post Routes", () => {
 
       const response = await app.inject({
         method: "PATCH",
-        url: "/api/admin/posts/bulk",
+        url: "/admin/posts/bulk",
         headers: { cookie },
         payload: { ids: [post1.id, post2.id], action: "update", categoryId: cat2.id },
       });
@@ -1876,7 +1876,7 @@ describe("Post Routes", () => {
 
       const getRes = await app.inject({
         method: "GET",
-        url: `/api/admin/posts/${post1.id}`,
+        url: `/admin/posts/${post1.id}`,
         headers: { cookie },
       });
       expect(getRes.json().post.categoryId).toBe(cat2.id);
@@ -1892,7 +1892,7 @@ describe("Post Routes", () => {
 
       const response = await app.inject({
         method: "PATCH",
-        url: "/api/admin/posts/bulk",
+        url: "/admin/posts/bulk",
         headers: { cookie },
         payload: { ids: [post1.id, post2.id], action: "update", commentStatus: "locked" },
       });
@@ -1901,7 +1901,7 @@ describe("Post Routes", () => {
 
       const getRes = await app.inject({
         method: "GET",
-        url: `/api/admin/posts/${post1.id}`,
+        url: `/admin/posts/${post1.id}`,
         headers: { cookie },
       });
       expect(getRes.json().post.commentStatus).toBe("locked");
@@ -1915,7 +1915,7 @@ describe("Post Routes", () => {
 
       const response = await app.inject({
         method: "PATCH",
-        url: "/api/admin/posts/bulk",
+        url: "/admin/posts/bulk",
         headers: { cookie },
         payload: { ids: [post.id], action: "update", categoryId: 99999 },
       });
@@ -1931,7 +1931,7 @@ describe("Post Routes", () => {
 
       const response = await app.inject({
         method: "PATCH",
-        url: "/api/admin/posts/bulk",
+        url: "/admin/posts/bulk",
         headers: { cookie },
         payload: { ids: [post.id], action: "update" },
       });
@@ -1949,7 +1949,7 @@ describe("Post Routes", () => {
 
       const response = await app.inject({
         method: "PATCH",
-        url: "/api/admin/posts/bulk",
+        url: "/admin/posts/bulk",
         headers: { cookie },
         payload: { ids: [post1.id, post2.id], action: "soft_delete" },
       });
@@ -1959,7 +1959,7 @@ describe("Post Routes", () => {
       // includeDeleted=true로 조회 시 deletedAt이 있어야 함
       const listRes = await app.inject({
         method: "GET",
-        url: "/api/admin/posts?includeDeleted=true",
+        url: "/admin/posts?includeDeleted=true",
         headers: { cookie },
       });
       const data = listRes.json().data;
@@ -1981,7 +1981,7 @@ describe("Post Routes", () => {
       // 먼저 소프트 삭제
       await app.inject({
         method: "PATCH",
-        url: "/api/admin/posts/bulk",
+        url: "/admin/posts/bulk",
         headers: { cookie },
         payload: { ids: [post1.id, post2.id], action: "soft_delete" },
       });
@@ -1989,7 +1989,7 @@ describe("Post Routes", () => {
       // 복원
       const response = await app.inject({
         method: "PATCH",
-        url: "/api/admin/posts/bulk",
+        url: "/admin/posts/bulk",
         headers: { cookie },
         payload: { ids: [post1.id, post2.id], action: "restore" },
       });
@@ -1998,7 +1998,7 @@ describe("Post Routes", () => {
 
       const getRes = await app.inject({
         method: "GET",
-        url: `/api/admin/posts/${post1.id}`,
+        url: `/admin/posts/${post1.id}`,
         headers: { cookie },
       });
       expect(getRes.json().post.deletedAt).toBeNull();
@@ -2025,7 +2025,7 @@ describe("Post Routes", () => {
 
       const response = await app.inject({
         method: "PATCH",
-        url: "/api/admin/posts/bulk",
+        url: "/admin/posts/bulk",
         headers: { cookie },
         payload: { ids: [deletedPinnedPost.id], action: "restore" },
       });
@@ -2044,7 +2044,7 @@ describe("Post Routes", () => {
 
       const response = await app.inject({
         method: "PATCH",
-        url: "/api/admin/posts/bulk",
+        url: "/admin/posts/bulk",
         headers: { cookie },
         payload: { ids: [post1.id, post2.id], action: "hard_delete" },
       });
@@ -2053,7 +2053,7 @@ describe("Post Routes", () => {
 
       const getRes = await app.inject({
         method: "GET",
-        url: `/api/admin/posts/${post1.id}`,
+        url: `/admin/posts/${post1.id}`,
         headers: { cookie },
       });
       expect(getRes.statusCode).toBe(404);
@@ -2067,7 +2067,7 @@ describe("Post Routes", () => {
       // post1: orphan-tag-bulk (다른 글 없음)
       const res1 = await app.inject({
         method: "POST",
-        url: "/api/admin/posts",
+        url: "/admin/posts",
         headers: { cookie },
         payload: {
           title: "Bulk Post 1",
@@ -2079,7 +2079,7 @@ describe("Post Routes", () => {
       // post2: shared-tag-bulk (post3과 공유)
       const res2 = await app.inject({
         method: "POST",
-        url: "/api/admin/posts",
+        url: "/admin/posts",
         headers: { cookie },
         payload: {
           title: "Bulk Post 2",
@@ -2091,7 +2091,7 @@ describe("Post Routes", () => {
       // post3: shared-tag-bulk 공유
       await app.inject({
         method: "POST",
-        url: "/api/admin/posts",
+        url: "/admin/posts",
         headers: { cookie },
         payload: {
           title: "Bulk Post 3",
@@ -2103,7 +2103,7 @@ describe("Post Routes", () => {
 
       const bulkRes = await app.inject({
         method: "PATCH",
-        url: "/api/admin/posts/bulk",
+        url: "/admin/posts/bulk",
         headers: { cookie },
         payload: {
           ids: [res1.json().post.id, res2.json().post.id],
@@ -2135,7 +2135,7 @@ describe("Post Routes", () => {
 
       const response = await app.inject({
         method: "PATCH",
-        url: "/api/admin/posts/bulk",
+        url: "/admin/posts/bulk",
         headers: { cookie },
         payload: { ids: [post.id, post.id], action: "soft_delete" },
       });
@@ -2152,7 +2152,7 @@ describe("Post Routes", () => {
 
       const response = await app.inject({
         method: "PATCH",
-        url: "/api/admin/posts/bulk",
+        url: "/admin/posts/bulk",
         headers: { cookie },
         payload: { ids: [post.id], action: "soft_delete", categoryId: cat2.id },
       });
@@ -2168,7 +2168,7 @@ describe("Post Routes", () => {
 
       const response = await app.inject({
         method: "PATCH",
-        url: "/api/admin/posts/bulk",
+        url: "/admin/posts/bulk",
         headers: { cookie },
         payload: { ids: [post.id, 99999], action: "soft_delete" },
       });
@@ -2178,7 +2178,7 @@ describe("Post Routes", () => {
       // post는 삭제되지 않아야 함 (트랜잭션 롤백)
       const getRes = await app.inject({
         method: "GET",
-        url: `/api/admin/posts/${post.id}`,
+        url: `/admin/posts/${post.id}`,
         headers: { cookie },
       });
       expect(getRes.json().post.deletedAt).toBeNull();
@@ -2187,7 +2187,7 @@ describe("Post Routes", () => {
     it("비인증 → 403", async () => {
       const response = await app.inject({
         method: "PATCH",
-        url: "/api/admin/posts/bulk",
+        url: "/admin/posts/bulk",
         payload: { ids: [1], action: "soft_delete" },
       });
       expect(response.statusCode).toBe(403);

--- a/test/routes/settings.test.ts
+++ b/test/routes/settings.test.ts
@@ -12,7 +12,7 @@ describe("Settings Routes", () => {
   async function getCsrfHeaders(cookie?: string): Promise<Record<string, string>> {
     const response = await app.inject({
       method: "GET",
-      url: "/api/auth/csrf-token",
+      url: "/auth/csrf-token",
       headers: cookie ? { cookie } : undefined,
     });
     const setCookie = response.headers["set-cookie"];
@@ -40,11 +40,11 @@ describe("Settings Routes", () => {
     await truncateAll();
   });
 
-  describe("GET /api/settings/guestbook", () => {
+  describe("GET /settings/guestbook", () => {
     it("기본 방명록 활성 상태 조회 → 200 + enabled=true", async () => {
       const response = await app.inject({
         method: "GET",
-        url: "/api/settings/guestbook",
+        url: "/settings/guestbook",
       });
 
       expect(response.statusCode).toBe(200);
@@ -52,12 +52,12 @@ describe("Settings Routes", () => {
     });
   });
 
-  describe("PATCH /api/admin/settings/guestbook", () => {
+  describe("PATCH /admin/settings/guestbook", () => {
     it("관리자 인증 없이 접근 → 403", async () => {
       const csrfHeaders = await getCsrfHeaders();
       const response = await app.inject({
         method: "PATCH",
-        url: "/api/admin/settings/guestbook",
+        url: "/admin/settings/guestbook",
         headers: csrfHeaders,
         payload: { enabled: false },
       });
@@ -72,7 +72,7 @@ describe("Settings Routes", () => {
 
       const response = await app.inject({
         method: "PATCH",
-        url: "/api/admin/settings/guestbook",
+        url: "/admin/settings/guestbook",
         headers: csrfHeaders,
         payload: { enabled: false },
       });

--- a/test/routes/stats.test.ts
+++ b/test/routes/stats.test.ts
@@ -12,7 +12,7 @@ describe("Stats Routes", () => {
   async function getCsrfHeaders(cookie?: string): Promise<Record<string, string>> {
     const response = await app.inject({
       method: "GET",
-      url: "/api/auth/csrf-token",
+      url: "/auth/csrf-token",
       headers: cookie ? { cookie } : undefined,
     });
     const setCookie = response.headers["set-cookie"];
@@ -40,14 +40,14 @@ describe("Stats Routes", () => {
     await truncateAll();
   });
 
-  // ===== POST /api/stats/view =====
+  // ===== POST /stats/view =====
 
-  describe("POST /api/stats/view", () => {
+  describe("POST /stats/view", () => {
     it("postId 없이 사이트 전체 조회수 기록 → 200", async () => {
       const csrfHeaders = await getCsrfHeaders();
       const response = await app.inject({
         method: "POST",
-        url: "/api/stats/view",
+        url: "/stats/view",
         headers: csrfHeaders,
         remoteAddress: "10.0.0.1",
         payload: {},
@@ -67,7 +67,7 @@ describe("Stats Routes", () => {
 
       const response = await app.inject({
         method: "POST",
-        url: "/api/stats/view",
+        url: "/stats/view",
         headers: csrfHeaders,
         remoteAddress: "10.0.0.2",
         payload: { postId: post.id },
@@ -81,7 +81,7 @@ describe("Stats Routes", () => {
       const csrfHeaders = await getCsrfHeaders();
       const response = await app.inject({
         method: "POST",
-        url: "/api/stats/view",
+        url: "/stats/view",
         headers: csrfHeaders,
         remoteAddress: "10.0.0.3",
         payload: { postId: 99999 },
@@ -100,7 +100,7 @@ describe("Stats Routes", () => {
 
       const response = await app.inject({
         method: "POST",
-        url: "/api/stats/view",
+        url: "/stats/view",
         headers: csrfHeaders,
         remoteAddress: "10.0.0.4",
         payload: { postId: post.id },
@@ -119,7 +119,7 @@ describe("Stats Routes", () => {
 
       await app.inject({
         method: "POST",
-        url: "/api/stats/view",
+        url: "/stats/view",
         headers: csrfHeaders,
         remoteAddress: "1.2.3.4",
         payload: { postId: post.id },
@@ -127,7 +127,7 @@ describe("Stats Routes", () => {
 
       const response = await app.inject({
         method: "POST",
-        url: "/api/stats/view",
+        url: "/stats/view",
         headers: csrfHeaders,
         remoteAddress: "1.2.3.4",
         payload: { postId: post.id },
@@ -147,7 +147,7 @@ describe("Stats Routes", () => {
 
       const postRes = await app.inject({
         method: "POST",
-        url: "/api/stats/view",
+        url: "/stats/view",
         headers: csrfHeaders,
         remoteAddress: "10.0.0.6",
         payload: { postId: post.id },
@@ -155,7 +155,7 @@ describe("Stats Routes", () => {
 
       const siteRes = await app.inject({
         method: "POST",
-        url: "/api/stats/view",
+        url: "/stats/view",
         headers: csrfHeaders,
         remoteAddress: "10.0.0.6",
         payload: {},
@@ -166,13 +166,13 @@ describe("Stats Routes", () => {
     });
   });
 
-  // ===== GET /api/stats/popular =====
+  // ===== GET /stats/popular =====
 
-  describe("GET /api/stats/popular", () => {
+  describe("GET /stats/popular", () => {
     it("데이터 없으면 빈 배열", async () => {
       const response = await app.inject({
         method: "GET",
-        url: "/api/stats/popular",
+        url: "/stats/popular",
       });
 
       expect(response.statusCode).toBe(200);
@@ -198,7 +198,7 @@ describe("Stats Routes", () => {
 
       const response = await app.inject({
         method: "GET",
-        url: "/api/stats/popular?limit=10&days=7",
+        url: "/stats/popular?limit=10&days=7",
       });
 
       expect(response.statusCode).toBe(200);
@@ -223,7 +223,7 @@ describe("Stats Routes", () => {
 
       const response = await app.inject({
         method: "GET",
-        url: "/api/stats/popular",
+        url: "/stats/popular",
       });
 
       expect(response.statusCode).toBe(200);
@@ -246,7 +246,7 @@ describe("Stats Routes", () => {
 
       const response = await app.inject({
         method: "GET",
-        url: "/api/stats/popular?limit=3",
+        url: "/stats/popular?limit=3",
       });
 
       expect(response.statusCode).toBe(200);
@@ -254,13 +254,13 @@ describe("Stats Routes", () => {
     });
   });
 
-  // ===== GET /api/stats/total-views =====
+  // ===== GET /stats/total-views =====
 
-  describe("GET /api/stats/total-views", () => {
+  describe("GET /stats/total-views", () => {
     it("데이터 없으면 0 반환", async () => {
       const response = await app.inject({
         method: "GET",
-        url: "/api/stats/total-views",
+        url: "/stats/total-views",
       });
 
       expect(response.statusCode).toBe(200);
@@ -279,7 +279,7 @@ describe("Stats Routes", () => {
 
       const response = await app.inject({
         method: "GET",
-        url: "/api/stats/total-views",
+        url: "/stats/total-views",
       });
 
       expect(response.statusCode).toBe(200);
@@ -298,7 +298,7 @@ describe("Stats Routes", () => {
 
       const response = await app.inject({
         method: "GET",
-        url: "/api/stats/total-views",
+        url: "/stats/total-views",
       });
 
       expect(response.statusCode).toBe(200);
@@ -306,13 +306,13 @@ describe("Stats Routes", () => {
     });
   });
 
-  // ===== GET /api/admin/stats/dashboard =====
+  // ===== GET /admin/stats/dashboard =====
 
-  describe("GET /api/admin/stats/dashboard", () => {
+  describe("GET /admin/stats/dashboard", () => {
     it("관리자 인증 없으면 403", async () => {
       const response = await app.inject({
         method: "GET",
-        url: "/api/admin/stats/dashboard",
+        url: "/admin/stats/dashboard",
       });
 
       expect(response.statusCode).toBe(403);
@@ -329,7 +329,7 @@ describe("Stats Routes", () => {
 
       const response = await app.inject({
         method: "GET",
-        url: "/api/admin/stats/dashboard",
+        url: "/admin/stats/dashboard",
         headers: { cookie },
       });
 
@@ -353,7 +353,7 @@ describe("Stats Routes", () => {
 
       const response = await app.inject({
         method: "GET",
-        url: "/api/admin/stats/dashboard",
+        url: "/admin/stats/dashboard",
         headers: { cookie },
       });
 

--- a/test/routes/tags.test.ts
+++ b/test/routes/tags.test.ts
@@ -21,11 +21,11 @@ describe("Tag Routes", () => {
     await truncateAll();
   });
 
-  describe("GET /api/tags", () => {
+  describe("GET /tags", () => {
     it("게시글이 없으면 빈 배열 반환", async () => {
       const response = await app.inject({
         method: "GET",
-        url: "/api/tags",
+        url: "/tags",
       });
 
       expect(response.statusCode).toBe(200);
@@ -39,7 +39,7 @@ describe("Tag Routes", () => {
 
       await app.inject({
         method: "POST",
-        url: "/api/admin/posts",
+        url: "/admin/posts",
         headers: { cookie },
         payload: {
           title: "Post One",
@@ -53,7 +53,7 @@ describe("Tag Routes", () => {
 
       await app.inject({
         method: "POST",
-        url: "/api/admin/posts",
+        url: "/admin/posts",
         headers: { cookie },
         payload: {
           title: "Post Two",
@@ -67,7 +67,7 @@ describe("Tag Routes", () => {
 
       await app.inject({
         method: "POST",
-        url: "/api/admin/posts",
+        url: "/admin/posts",
         headers: { cookie },
         payload: {
           title: "Private Post",
@@ -81,7 +81,7 @@ describe("Tag Routes", () => {
 
       await app.inject({
         method: "POST",
-        url: "/api/admin/posts",
+        url: "/admin/posts",
         headers: { cookie },
         payload: {
           title: "Draft Post",
@@ -95,7 +95,7 @@ describe("Tag Routes", () => {
 
       const response = await app.inject({
         method: "GET",
-        url: "/api/tags",
+        url: "/tags",
       });
 
       expect(response.statusCode).toBe(200);
@@ -119,7 +119,7 @@ describe("Tag Routes", () => {
 
       await app.inject({
         method: "POST",
-        url: "/api/admin/posts",
+        url: "/admin/posts",
         headers: { cookie },
         payload: {
           title: "Post One",
@@ -133,7 +133,7 @@ describe("Tag Routes", () => {
 
       await app.inject({
         method: "POST",
-        url: "/api/admin/posts",
+        url: "/admin/posts",
         headers: { cookie },
         payload: {
           title: "Post Two",
@@ -152,7 +152,7 @@ describe("Tag Routes", () => {
 
       const response = await app.inject({
         method: "GET",
-        url: "/api/tags",
+        url: "/tags",
       });
 
       expect(response.statusCode).toBe(200);

--- a/test/routes/user.test.ts
+++ b/test/routes/user.test.ts
@@ -15,7 +15,7 @@ import {
   seedPost,
 } from "@test/helpers/seed";
 
-describe("User Routes (/api/user)", () => {
+describe("User Routes (/user)", () => {
   let app: FastifyInstance;
 
   beforeAll(async () => {
@@ -30,9 +30,9 @@ describe("User Routes (/api/user)", () => {
     await truncateAll();
   });
 
-  // ===== GET /api/user/me =====
+  // ===== GET /user/me =====
 
-  describe("GET /api/user/me", () => {
+  describe("GET /user/me", () => {
     it("인증된 OAuth 유저 → 200 + 프로필 반환", async () => {
       const user = await seedOAuthUser({
         displayName: "테스트 유저",
@@ -43,7 +43,7 @@ describe("User Routes (/api/user)", () => {
 
       const response = await app.inject({
         method: "GET",
-        url: "/api/user/me",
+        url: "/user/me",
         headers: { cookie },
       });
 
@@ -62,23 +62,23 @@ describe("User Routes (/api/user)", () => {
     it("인증 없이 접근 → 401", async () => {
       const response = await app.inject({
         method: "GET",
-        url: "/api/user/me",
+        url: "/user/me",
       });
 
       expect(response.statusCode).toBe(401);
     });
   });
 
-  // ===== PUT /api/user/me =====
+  // ===== PUT /user/me =====
 
-  describe("PUT /api/user/me", () => {
+  describe("PUT /user/me", () => {
     it("displayName 수정 → 200 + 수정된 프로필", async () => {
       const user = await seedOAuthUser({ displayName: "이전 이름" });
       const cookie = await injectOAuthUser(user.id);
 
       const response = await app.inject({
         method: "PUT",
-        url: "/api/user/me",
+        url: "/user/me",
         headers: { cookie },
         payload: { displayName: "새 이름" },
       });
@@ -95,7 +95,7 @@ describe("User Routes (/api/user)", () => {
 
       const response = await app.inject({
         method: "PUT",
-        url: "/api/user/me",
+        url: "/user/me",
         headers: { cookie },
         payload: { avatarUrl: null },
       });
@@ -110,7 +110,7 @@ describe("User Routes (/api/user)", () => {
 
       const response = await app.inject({
         method: "PUT",
-        url: "/api/user/me",
+        url: "/user/me",
         headers: { cookie },
         payload: {},
       });
@@ -122,7 +122,7 @@ describe("User Routes (/api/user)", () => {
     it("인증 없이 접근 → 401", async () => {
       const response = await app.inject({
         method: "PUT",
-        url: "/api/user/me",
+        url: "/user/me",
         payload: { displayName: "테스트" },
       });
 
@@ -130,16 +130,16 @@ describe("User Routes (/api/user)", () => {
     });
   });
 
-  // ===== DELETE /api/user/me =====
+  // ===== DELETE /user/me =====
 
-  describe("DELETE /api/user/me", () => {
+  describe("DELETE /user/me", () => {
     it("회원 탈퇴 → 204 + deletedAt 설정", async () => {
       const user = await seedOAuthUser();
       const cookie = await injectOAuthUser(user.id);
 
       const response = await app.inject({
         method: "DELETE",
-        url: "/api/user/me",
+        url: "/user/me",
         headers: { cookie },
       });
 
@@ -154,20 +154,20 @@ describe("User Routes (/api/user)", () => {
       expect(updated?.deletedAt).not.toBeNull();
     });
 
-    it("탈퇴 후 세션 파기 → GET /api/user/me 401", async () => {
+    it("탈퇴 후 세션 파기 → GET /user/me 401", async () => {
       const user = await seedOAuthUser();
       const cookie = await injectOAuthUser(user.id);
 
       await app.inject({
         method: "DELETE",
-        url: "/api/user/me",
+        url: "/user/me",
         headers: { cookie },
       });
 
       // 동일 세션으로 재접근
       const meResponse = await app.inject({
         method: "GET",
-        url: "/api/user/me",
+        url: "/user/me",
         headers: { cookie },
       });
 
@@ -177,7 +177,7 @@ describe("User Routes (/api/user)", () => {
     it("인증 없이 접근 → 401", async () => {
       const response = await app.inject({
         method: "DELETE",
-        url: "/api/user/me",
+        url: "/user/me",
       });
 
       expect(response.statusCode).toBe(401);
@@ -211,7 +211,7 @@ describe("User Routes (/api/user)", () => {
 
       const response = await app.inject({
         method: "GET",
-        url: `/api/posts/${post.id}/comments`,
+        url: `/posts/${post.id}/comments`,
       });
 
       expect(response.statusCode).toBe(200);
@@ -241,7 +241,7 @@ describe("User Routes (/api/user)", () => {
 
       const response = await app.inject({
         method: "GET",
-        url: "/api/guestbook",
+        url: "/guestbook",
       });
 
       expect(response.statusCode).toBe(200);


### PR DESCRIPTION
## Summary

Closes #96

서버 API의 `/api` prefix를 제거하고 health, OAuth callback, Swagger 설명, 통합 테스트 경로를 새 계약에 맞게 정리합니다.

## Changes

| File | Change |
|------|--------|
| `src/app.ts` | health 경로를 `/health`, `/health/live`, `/health/ready`로 정리하고 모든 서버 route prefix에서 `/api` 제거 |
| `src/plugins/passport.ts` | Google/GitHub OAuth callback URL을 `/auth/*/callback`으로 변경 |
| `src/routes/**` | Swagger 설명과 주석에 남아 있던 `/api/...` 경로 문자열을 실제 계약과 일치하도록 수정 |
| `test/helpers/app.ts`, `test/routes/**` | 인증/CSRF/통합 테스트 요청 경로를 새 서버 경로로 전환 |

