### PR TITLE
feat: add server CI workflow (#98)

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -3,6 +3,8 @@ name: CI
 on:
   pull_request:
   push:
+    branches:
+      - main
 
 concurrency:
   group: ci-${{ github.workflow }}-${{ github.event.pull_request.number || github.ref }}
@@ -37,6 +39,7 @@ jobs:
       - name: Setup pnpm
         uses: pnpm/action-setup@v4
         with:
+          version: 10.33.0
           run_install: false
 
       - name: Setup Node.js

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,0 +1,83 @@
+name: CI
+
+on:
+  pull_request:
+  push:
+
+concurrency:
+  group: ci-${{ github.workflow }}-${{ github.event.pull_request.number || github.ref }}
+  cancel-in-progress: true
+
+jobs:
+  ci:
+    name: ci
+    runs-on: ubuntu-latest
+    timeout-minutes: 15
+
+    services:
+      mysql:
+        image: mysql:8.4
+        env:
+          MYSQL_DATABASE: pyosh_blog_test
+          MYSQL_USER: pyosh
+          MYSQL_PASSWORD: pyosh
+          MYSQL_ROOT_PASSWORD: root
+        ports:
+          - 3306:3306
+        options: >-
+          --health-cmd="mysqladmin ping -h 127.0.0.1 -proot"
+          --health-interval=10s
+          --health-timeout=5s
+          --health-retries=10
+
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@v4
+
+      - name: Setup pnpm
+        uses: pnpm/action-setup@v4
+        with:
+          run_install: false
+
+      - name: Setup Node.js
+        uses: actions/setup-node@v4
+        with:
+          node-version: 20
+          cache: pnpm
+
+      - name: Install dependencies
+        run: pnpm install --frozen-lockfile
+
+      - name: Write test environment
+        run: |
+          cat <<'EOF' > .env.test
+          NODE_ENV=test
+          SERVER_PORT=5500
+          CLIENT_PROTOCOL=http
+          CLIENT_HOST=localhost
+          CLIENT_PORT=3000
+          DB_HOST=127.0.0.1
+          DB_PORT=3306
+          DB_USER=pyosh
+          DB_PSWD=pyosh
+          DB_DTBS=pyosh_blog_test
+          SESSION_SECRET=test-session-secret
+          LOGIN_SUCCESS_PATH=/auth/success
+          LOGIN_FAILURE_PATH=/auth/failure
+          GOOGLE_CLIENT_ID=
+          GOOGLE_CLIENT_SECRET=
+          GITHUB_CLIENT_ID=
+          GITHUB_CLIENT_SECRET=
+          EOF
+
+      - name: Type check
+        run: pnpm compile:types
+
+      - name: Lint
+        run: pnpm lint
+
+      - name: Test
+        run: pnpm test
+
+      - name: Build
+        run: pnpm build


### PR DESCRIPTION
## Summary

Closes #98

Add a GitHub Actions CI workflow for the server repo so pull requests and pushes run type-check, lint, test, and build before merge.

## Changes

| File | Change |
|------|--------|
| `.github/workflows/ci.yml` | Added a CI workflow with `pull_request`/`push` triggers, concurrency cancellation, Node 20 + pnpm setup, MySQL service, generated `.env.test`, and `compile:types`/`lint`/`test`/`build` steps. |

## Screenshots

N/A

## Verification

- `pnpm compile:types` ✅
- `pnpm build` ✅
- `pnpm lint` ⚠️ fails on existing baseline lint errors unrelated to this workflow change
- `pnpm test` ⚠️ local run failed due DB access for `pyosh@127.0.0.1`; workflow provisions MySQL service for CI execution
