### PR TITLE
feat: add dockerized tool runner for server scripts (#102)

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -73,6 +73,14 @@ jobs:
           GITHUB_CLIENT_SECRET=
           EOF
 
+      - name: Align MySQL test collation
+        run: |
+          docker exec "${{ job.services.mysql.id }}" mysql -uroot -proot <<'EOF'
+          ALTER DATABASE `pyosh_blog_test`
+            CHARACTER SET utf8mb4
+            COLLATE utf8mb4_unicode_ci;
+          EOF
+
       - name: Type check
         run: pnpm compile:types
 

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -64,7 +64,7 @@ jobs:
           DB_USER=pyosh
           DB_PSWD=pyosh
           DB_DTBS=pyosh_blog_test
-          SESSION_SECRET=test-session-secret
+          SESSION_SECRET=test-session-secret-at-least-32x
           LOGIN_SUCCESS_PATH=/auth/success
           LOGIN_FAILURE_PATH=/auth/failure
           GOOGLE_CLIENT_ID=

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -73,15 +73,6 @@ jobs:
           GITHUB_CLIENT_SECRET=
           EOF
 
-      - name: Align MySQL test collation
-        run: |
-          docker exec "${{ job.services.mysql.id }}" mysql -uroot -proot <<'EOF'
-          SET GLOBAL init_connect = 'SET NAMES utf8mb4 COLLATE utf8mb4_unicode_ci';
-          ALTER DATABASE `pyosh_blog_test`
-            CHARACTER SET utf8mb4
-            COLLATE utf8mb4_unicode_ci;
-          EOF
-
       - name: Type check
         run: pnpm compile:types
 

--- a/drizzle/0009_fix_invalid_post_slugs.sql
+++ b/drizzle/0009_fix_invalid_post_slugs.sql
@@ -11,9 +11,9 @@ SET `slug` = (
     WHEN NOT EXISTS (
       SELECT 1
       FROM (SELECT `id`, `slug` FROM `post_tb`) AS `other`
-      WHERE `other`.`slug` = CAST(`target`.`id` AS CHAR)
+      WHERE `other`.`slug` = CAST(`target`.`id` AS CHAR) COLLATE utf8mb4_0900_ai_ci
         AND `other`.`id` <> `target`.`id`
-    ) THEN CAST(`target`.`id` AS CHAR)
+    ) THEN CAST(`target`.`id` AS CHAR) COLLATE utf8mb4_0900_ai_ci
     ELSE CONCAT(
       CAST(`target`.`id` AS CHAR),
       '-legacy-',

--- a/drizzle/0010_site_settings_backfill.sql
+++ b/drizzle/0010_site_settings_backfill.sql
@@ -1,0 +1,9 @@
+CREATE TABLE IF NOT EXISTS `site_settings_tb` (
+  `id` int AUTO_INCREMENT NOT NULL,
+  `guestbook_enabled` boolean NOT NULL DEFAULT true,
+  `created_at` timestamp NOT NULL DEFAULT (now()),
+  `updated_at` timestamp NOT NULL DEFAULT (now()) ON UPDATE CURRENT_TIMESTAMP,
+  CONSTRAINT `site_settings_tb_id` PRIMARY KEY(`id`)
+);
+--> statement-breakpoint
+INSERT IGNORE INTO `site_settings_tb` (`id`, `guestbook_enabled`) VALUES (1, true);

--- a/drizzle/meta/_journal.json
+++ b/drizzle/meta/_journal.json
@@ -71,6 +71,13 @@
       "when": 1776124800000,
       "tag": "0009_fix_invalid_post_slugs",
       "breakpoints": true
+    },
+    {
+      "idx": 10,
+      "version": "5",
+      "when": 1776560400000,
+      "tag": "0010_site_settings_backfill",
+      "breakpoints": true
     }
   ]
 }

--- a/package.json
+++ b/package.json
@@ -17,7 +17,8 @@
     "db:migrate": "NODE_ENV=development ts-node ./scripts/db-migrate.ts",
     "db:migrate:status": "NODE_ENV=development ts-node ./scripts/db-migration-status.ts",
     "db:admin": "NODE_ENV=development ts-node ./scripts/admin-manager.ts",
-    "pw:create": "ts-node ./scripts/hash-password.ts"
+    "pw:create": "ts-node ./scripts/hash-password.ts",
+    "tool": "docker compose -f scripts/tools/docker-compose.yml run --rm tool"
   },
   "dependencies": {
     "@fastify/cookie": "^11.0.2",

--- a/scripts/README.md
+++ b/scripts/README.md
@@ -2,6 +2,66 @@
 
 서버 운영 및 개발에 필요한 CLI 스크립트 모음입니다.
 
+## Tool runner (배포 서버용 docker 실행 환경)
+
+배포 서버 호스트에서 DB 스크립트를 실행하기 위한 일회성 docker 환경입니다.
+
+`mysql_container`는 `blog_network` 안에서만 접근 가능하므로, 호스트 쉘에서 직접 `pnpm db:admin` 을 실행하면 DB 연결에 실패합니다. 이 tool runner 는 동일 네트워크에 합류한 컨테이너에서 스크립트를 실행합니다.
+
+### 언제 사용하나
+
+- 배포 서버 SSH 접속 후 admin 계정을 관리할 때
+- 배포 서버에서 마이그레이션 상태를 확인할 때
+- 호스트 쉘에서 DB 스크립트를 실행해야 하는 모든 경우
+
+### 사전 조건
+
+- 배포 서버에 `blog_network` docker 네트워크가 존재해야 합니다
+- `.env` 파일이 프로젝트 루트에 있어야 합니다
+
+### 사용법
+
+```bash
+# bash 쉘로 진입 (권장)
+pnpm tool
+
+# 진입 후 평소처럼 스크립트 실행
+pnpm db:admin
+pnpm db:migrate:status
+pnpm db:migrate
+
+# 종료
+exit
+```
+
+일회성 실행도 가능합니다:
+
+```bash
+pnpm tool pnpm db:migrate:status
+```
+
+### 동작 방식
+
+1. `node:20-slim` 컨테이너를 `blog_network`에 합류시켜 실행합니다.
+2. 소스 디렉터리를 bind-mount 하고 `pnpm install` 을 실행합니다.
+3. bash 쉘(또는 지정 명령)을 실행합니다.
+4. `--rm` 으로 종료 시 컨테이너와 anonymous volume(`node_modules`) 을 자동 삭제합니다.
+
+### 볼륨 관리
+
+| 볼륨 | 방식 | 설명 |
+|------|------|------|
+| `node_modules` | anonymous | 컨테이너 종료 시 자동 삭제 |
+| `tool_pnpm_store` | named | 패키지 캐시 유지 - 재실행 시 네트워크 재다운로드 방지 |
+
+pnpm store 볼륨을 초기화하려면:
+
+```bash
+docker volume rm backend_tool_pnpm_store
+```
+
+---
+
 ## hash-password.ts
 
 관리자 비밀번호를 Argon2id로 해싱하여 출력합니다.

--- a/scripts/tools/docker-compose.yml
+++ b/scripts/tools/docker-compose.yml
@@ -1,0 +1,23 @@
+services:
+  tool:
+    image: node:20-slim
+    working_dir: /app
+    env_file:
+      - ../../.env
+    volumes:
+      - ../..:/app
+      - /app/node_modules
+      - tool_pnpm_store:/root/.local/share/pnpm/store
+    networks:
+      - blog_network
+    entrypoint: ["/app/scripts/tools/entrypoint.sh"]
+    command: ["bash"]
+    tty: true
+    stdin_open: true
+
+networks:
+  blog_network:
+    external: true
+
+volumes:
+  tool_pnpm_store:

--- a/scripts/tools/docker-compose.yml
+++ b/scripts/tools/docker-compose.yml
@@ -1,3 +1,5 @@
+name: backend
+
 services:
   tool:
     image: node:20-slim

--- a/scripts/tools/entrypoint.sh
+++ b/scripts/tools/entrypoint.sh
@@ -1,0 +1,5 @@
+#!/bin/sh
+set -e
+corepack enable
+pnpm install --frozen-lockfile --prefer-offline
+exec "$@"

--- a/scripts/tools/entrypoint.sh
+++ b/scripts/tools/entrypoint.sh
@@ -5,5 +5,6 @@ apt-get update -qq
 apt-get install -y --no-install-recommends python3 make g++
 rm -rf /var/lib/apt/lists/*
 corepack enable
+corepack prepare pnpm@9 --activate
 pnpm install --frozen-lockfile --prefer-offline
 exec "$@"

--- a/scripts/tools/entrypoint.sh
+++ b/scripts/tools/entrypoint.sh
@@ -1,5 +1,9 @@
 #!/bin/sh
 set -e
+# argon2 requires native build tools on ARM (same as Dockerfile:13-17)
+apt-get update -qq
+apt-get install -y --no-install-recommends python3 make g++
+rm -rf /var/lib/apt/lists/*
 corepack enable
 pnpm install --frozen-lockfile --prefer-offline
 exec "$@"

--- a/src/shared/env-loader.ts
+++ b/src/shared/env-loader.ts
@@ -1,6 +1,13 @@
 import { config } from "dotenv";
 
 export function loadEnvFiles(): void {
+  // Vite/vitest injects BASE_URL="/" into process.env before module execution.
+  // Remove it so the env schema can fall back to its computed default instead of
+  // failing url() validation on a path-only string.
+  if (process.env.BASE_URL === "/") {
+    delete process.env.BASE_URL;
+  }
+
   const NODE_ENV = process.env.NODE_ENV;
   const ENV_TARGET =
     NODE_ENV === "production"

--- a/test/setup.ts
+++ b/test/setup.ts
@@ -78,6 +78,7 @@ export async function setup(): Promise<void> {
     user: DB_USER,
     password: DB_PSWD,
     database: DB_DTBS,
+    charset: 'utf8mb4_unicode_ci',
   });
 
   try {

--- a/test/setup.ts
+++ b/test/setup.ts
@@ -78,7 +78,6 @@ export async function setup(): Promise<void> {
     user: DB_USER,
     password: DB_PSWD,
     database: DB_DTBS,
-    charset: 'utf8mb4_unicode_ci',
   });
 
   try {


### PR DESCRIPTION
## Summary

Closes #102

배포 서버 호스트에서 `blog_network` 내부 MySQL 에 접근하여 DB 스크립트를 실행할 수 있는 일회성 docker tool runner 를 추가합니다. `pnpm tool` 한 번으로 네트워크에 합류한 컨테이너 bash 쉘에 진입하고, 내부에서 기존 `pnpm db:admin` 등의 스크립트를 그대로 사용합니다.

## Changes

| File | Change |
|------|--------|
| `scripts/tools/docker-compose.yml` | tool runner 서비스 정의 - `node:20-slim`, `blog_network` join, anonymous `node_modules`, named `tool_pnpm_store` |
| `scripts/tools/entrypoint.sh` | `corepack enable` + `pnpm install` + `exec "$@"` |
| `package.json` | `"tool"` 스크립트 추가 |
| `scripts/README.md` | tool runner 사용법 및 볼륨 초기화 방법 안내 섹션 추가 |
