### PR TITLE
fix: share admin session cookie across subdomains (#104)

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -23,6 +23,7 @@ DB_DTBS=pyosh_blog
 
 # Session
 SESSION_SECRET=replace-with-long-random-string
+# SESSION_COOKIE_DOMAIN=.pyosh.com
 
 # OAuth redirects
 LOGIN_SUCCESS_PATH=/auth/success

--- a/README.md
+++ b/README.md
@@ -26,6 +26,7 @@ Key variables:
 | `CLIENT_PROTOCOL` / `CLIENT_HOST` / `CLIENT_PORT` | Frontend origin (used for CORS and redirects) |
 | `DB_HOST` / `DB_PORT` / `DB_USER` / `DB_PSWD` / `DB_DTBS` | MySQL connection |
 | `SESSION_SECRET` | Session signing secret |
+| `SESSION_COOKIE_DOMAIN` | Optional shared cookie domain for cross-subdomain session reuse |
 | `GOOGLE_CLIENT_ID` / `GOOGLE_CLIENT_SECRET` | Google OAuth app credentials |
 | `GITHUB_CLIENT_ID` / `GITHUB_CLIENT_SECRET` | GitHub OAuth app credentials |
 | `LOGIN_SUCCESS_PATH` / `LOGIN_FAILURE_PATH` | Post-OAuth redirect paths on the frontend |

--- a/src/plugins/session.ts
+++ b/src/plugins/session.ts
@@ -16,6 +16,9 @@ const sessionPlugin: FastifyPluginAsync = async (fastify) => {
     saveUninitialized: false,
     cookie: {
       httpOnly: true,
+      ...(env.SESSION_COOKIE_DOMAIN
+        ? { domain: env.SESSION_COOKIE_DOMAIN }
+        : {}),
       secure: isProduction,
       sameSite: "lax", // 'strict'은 OAuth 콜백(외부 리다이렉트) 시 쿠키 누락 발생; CSRF 토큰이 주 방어수단
       path: "/",

--- a/src/shared/env.ts
+++ b/src/shared/env.ts
@@ -37,6 +37,7 @@ const envSchema = z
 
     // 세션 설정
     SESSION_SECRET: z.string().min(1),
+    SESSION_COOKIE_DOMAIN: z.string().min(1).optional(),
 
     // OAuth 리다이렉트 경로
     LOGIN_SUCCESS_PATH: z.string().min(1),


### PR DESCRIPTION
## Summary

Closes #104

Share the Fastify session cookie across `*.pyosh.com` subdomains by making the cookie domain configurable via environment variable. This keeps local development unchanged while allowing production to set `SESSION_COOKIE_DOMAIN=.pyosh.com` so the Next middleware on `www.pyosh.com` can see the admin session created by `api.pyosh.com`.

## Changes

| File | Change |
|------|--------|
| `src/shared/env.ts` | Added optional `SESSION_COOKIE_DOMAIN` environment variable support |
| `src/plugins/session.ts` | Applied the configured cookie `domain` to the Fastify session cookie when present |
| `.env.example` | Documented `SESSION_COOKIE_DOMAIN=.pyosh.com` for production shared-session setup |
| `README.md` | Added the new deployment environment variable to the server environment reference |

## Verification

- `pnpm compile:types` ✅
- `pnpm test` ⚠️ blocked by missing Rollup optional dependency in the worktree environment: `@rollup/rollup-linux-arm64-gnu`

