### PR TITLE
fix: trust proxy for admin session cookies (#106)

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -24,6 +24,7 @@ DB_DTBS=pyosh_blog
 # Session
 SESSION_SECRET=replace-with-long-random-string
 # SESSION_COOKIE_DOMAIN=.pyosh.com
+# TRUSTED_PROXY_RANGES=127.0.0.1/32,::1/128
 
 # OAuth redirects
 LOGIN_SUCCESS_PATH=/auth/success

--- a/src/app.ts
+++ b/src/app.ts
@@ -64,6 +64,7 @@ export async function buildApp(): Promise<FastifyInstance> {
   // Fastify 인스턴스 생성
   const fastify = Fastify({
     ...buildFastifyLoggerConfig(),
+    trustProxy: true,
   }).withTypeProvider<ZodTypeProvider>();
 
   // Zod validator & serializer 설정

--- a/src/app.ts
+++ b/src/app.ts
@@ -99,6 +99,7 @@ export async function buildApp(): Promise<FastifyInstance> {
   fastify.addHook("onRequest", (request, _, done) => {
     if (isTrustedProxyPeer(request.socket.remoteAddress)) {
       done();
+
       return;
     }
 

--- a/src/app.ts
+++ b/src/app.ts
@@ -60,24 +60,61 @@ import {
   getMemoryUsage,
 } from "@src/services/health.service";
 import { StatsService } from "@src/services/stats.service";
+import { env } from "@src/shared/env";
 
-const trustedProxyPeers = new BlockList();
-trustedProxyPeers.addAddress("127.0.0.1", "ipv4");
-trustedProxyPeers.addAddress("::1", "ipv6");
-trustedProxyPeers.addSubnet("10.0.0.0", 8, "ipv4");
-trustedProxyPeers.addSubnet("172.16.0.0", 12, "ipv4");
-trustedProxyPeers.addSubnet("192.168.0.0", 16, "ipv4");
-trustedProxyPeers.addSubnet("fc00::", 7, "ipv6");
-trustedProxyPeers.addSubnet("fe80::", 10, "ipv6");
-
-function isTrustedProxyPeer(remoteAddress: string | undefined): boolean {
-  if (!remoteAddress) {
-    return false;
+function normalizeIp(address: string | undefined): string | null {
+  if (!address) {
+    return null;
   }
 
-  const normalized = remoteAddress.startsWith("::ffff:")
-    ? remoteAddress.slice(7)
-    : remoteAddress;
+  return address.startsWith("::ffff:") ? address.slice(7) : address;
+}
+
+function buildTrustedProxyPeers(): BlockList {
+  const peers = new BlockList();
+  const entries = env.TRUSTED_PROXY_RANGES?.split(",")
+    .map((entry) => entry.trim())
+    .filter(Boolean);
+
+  for (const entry of entries ?? []) {
+    const [address, prefixLength] = entry.split("/");
+    const normalizedAddress = normalizeIp(address);
+
+    if (!normalizedAddress) {
+      continue;
+    }
+
+    const family = isIP(normalizedAddress);
+
+    if (family === 0) {
+      continue;
+    }
+
+    const type = family === 4 ? "ipv4" : "ipv6";
+
+    if (prefixLength === undefined) {
+      peers.addAddress(normalizedAddress, type);
+      continue;
+    }
+
+    const prefix = Number(prefixLength);
+
+    if (Number.isInteger(prefix)) {
+      peers.addSubnet(normalizedAddress, prefix, type);
+    }
+  }
+
+  return peers;
+}
+
+const trustedProxyPeers = buildTrustedProxyPeers();
+
+function isTrustedProxyPeer(remoteAddress: string | undefined): boolean {
+  const normalized = normalizeIp(remoteAddress);
+
+  if (!normalized) {
+    return false;
+  }
   const family = isIP(normalized);
 
   if (family === 0) {
@@ -91,9 +128,7 @@ export async function buildApp(): Promise<FastifyInstance> {
   // Fastify 인스턴스 생성
   const fastify = Fastify({
     ...buildFastifyLoggerConfig(),
-    // Trust forwarded headers only from local/private proxy hops such as the
-    // Cloudflare Tunnel origin connection, not from arbitrary direct clients.
-    trustProxy: true,
+    trustProxy: isTrustedProxyPeer,
   }).withTypeProvider<ZodTypeProvider>();
 
   fastify.addHook("onRequest", (request, _, done) => {

--- a/src/app.ts
+++ b/src/app.ts
@@ -1,3 +1,4 @@
+import { BlockList, isIP } from "node:net";
 import Fastify, { FastifyInstance, FastifyError } from "fastify";
 import {
   ZodTypeProvider,
@@ -60,12 +61,54 @@ import {
 } from "@src/services/health.service";
 import { StatsService } from "@src/services/stats.service";
 
+const trustedProxyPeers = new BlockList();
+trustedProxyPeers.addAddress("127.0.0.1", "ipv4");
+trustedProxyPeers.addAddress("::1", "ipv6");
+trustedProxyPeers.addSubnet("10.0.0.0", 8, "ipv4");
+trustedProxyPeers.addSubnet("172.16.0.0", 12, "ipv4");
+trustedProxyPeers.addSubnet("192.168.0.0", 16, "ipv4");
+trustedProxyPeers.addSubnet("fc00::", 7, "ipv6");
+trustedProxyPeers.addSubnet("fe80::", 10, "ipv6");
+
+function isTrustedProxyPeer(remoteAddress: string | undefined): boolean {
+  if (!remoteAddress) {
+    return false;
+  }
+
+  const normalized = remoteAddress.startsWith("::ffff:")
+    ? remoteAddress.slice(7)
+    : remoteAddress;
+  const family = isIP(normalized);
+
+  if (family === 0) {
+    return false;
+  }
+
+  return trustedProxyPeers.check(normalized, family === 4 ? "ipv4" : "ipv6");
+}
+
 export async function buildApp(): Promise<FastifyInstance> {
   // Fastify 인스턴스 생성
   const fastify = Fastify({
     ...buildFastifyLoggerConfig(),
+    // Trust forwarded headers only from local/private proxy hops such as the
+    // Cloudflare Tunnel origin connection, not from arbitrary direct clients.
     trustProxy: true,
   }).withTypeProvider<ZodTypeProvider>();
+
+  fastify.addHook("onRequest", (request, _, done) => {
+    if (isTrustedProxyPeer(request.socket.remoteAddress)) {
+      done();
+      return;
+    }
+
+    delete request.headers.forwarded;
+    delete request.headers["x-forwarded-for"];
+    delete request.headers["x-forwarded-host"];
+    delete request.headers["x-forwarded-port"];
+    delete request.headers["x-forwarded-proto"];
+    done();
+  });
 
   // Zod validator & serializer 설정
   fastify.setValidatorCompiler(validatorCompiler);

--- a/src/shared/env.ts
+++ b/src/shared/env.ts
@@ -38,6 +38,7 @@ const envSchema = z
     // 세션 설정
     SESSION_SECRET: z.string().min(1),
     SESSION_COOKIE_DOMAIN: z.string().min(1).optional(),
+    TRUSTED_PROXY_RANGES: z.string().min(1).optional(),
 
     // OAuth 리다이렉트 경로
     LOGIN_SUCCESS_PATH: z.string().min(1),

--- a/test/routes/auth.proxy.e2e.test.ts
+++ b/test/routes/auth.proxy.e2e.test.ts
@@ -52,6 +52,7 @@ describe("Auth Routes Behind HTTPS Proxy", () => {
     const response = await app.inject({
       method: "POST",
       url: "/auth/admin/login",
+      remoteAddress: "172.18.0.10",
       headers: {
         "x-forwarded-proto": "https",
         "x-forwarded-host": "api.pyosh.com",
@@ -66,5 +67,24 @@ describe("Auth Routes Behind HTTPS Proxy", () => {
     expect(response.headers["set-cookie"]).toEqual(expect.any(String));
     expect(response.headers["set-cookie"]).toContain("Secure");
     expect(response.headers["set-cookie"]).toContain("Domain=.pyosh.com");
+  });
+
+  it("ignores forwarded headers from untrusted public peers", async () => {
+    const response = await app.inject({
+      method: "POST",
+      url: "/auth/admin/login",
+      remoteAddress: "198.51.100.10",
+      headers: {
+        "x-forwarded-proto": "https",
+        "x-forwarded-for": "1.2.3.4",
+      },
+      payload: {
+        username: TEST_ADMIN_USERNAME,
+        password: TEST_ADMIN_PASSWORD,
+      },
+    });
+
+    expect(response.statusCode).toBe(200);
+    expect(response.headers["set-cookie"]).toBeUndefined();
   });
 });

--- a/test/routes/auth.proxy.e2e.test.ts
+++ b/test/routes/auth.proxy.e2e.test.ts
@@ -1,0 +1,70 @@
+import { mkdir } from "node:fs/promises";
+import { FastifyInstance } from "fastify";
+import { afterAll, beforeAll, beforeEach, describe, expect, it, vi } from "vitest";
+import { cleanup, TEST_ADMIN_PASSWORD, TEST_ADMIN_USERNAME } from "@test/helpers/app";
+import { seedAdmin, truncateAll } from "@test/helpers/seed";
+
+async function createProductionProxyApp(): Promise<FastifyInstance> {
+  vi.resetModules();
+  vi.doMock("@src/shared/env", async () => {
+    const actual = await vi.importActual<typeof import("@src/shared/env")>(
+      "@src/shared/env",
+    );
+
+    return {
+      ...actual,
+      env: {
+        ...actual.env,
+        NODE_ENV: "production" as const,
+        SESSION_COOKIE_DOMAIN: ".pyosh.com",
+      },
+    };
+  });
+
+  await mkdir("uploads", { recursive: true });
+
+  const { buildApp } = await import("@src/app");
+  const app = await buildApp();
+  await app.ready();
+
+  return app;
+}
+
+describe("Auth Routes Behind HTTPS Proxy", () => {
+  let app: FastifyInstance;
+
+  beforeAll(async () => {
+    app = await createProductionProxyApp();
+  });
+
+  afterAll(async () => {
+    await cleanup(app);
+    vi.doUnmock("@src/shared/env");
+    vi.resetModules();
+  });
+
+  beforeEach(async () => {
+    await truncateAll();
+    await seedAdmin();
+  });
+
+  it("issues a secure session cookie when login is forwarded over HTTPS", async () => {
+    const response = await app.inject({
+      method: "POST",
+      url: "/auth/admin/login",
+      headers: {
+        "x-forwarded-proto": "https",
+        "x-forwarded-host": "api.pyosh.com",
+      },
+      payload: {
+        username: TEST_ADMIN_USERNAME,
+        password: TEST_ADMIN_PASSWORD,
+      },
+    });
+
+    expect(response.statusCode).toBe(200);
+    expect(response.headers["set-cookie"]).toEqual(expect.any(String));
+    expect(response.headers["set-cookie"]).toContain("Secure");
+    expect(response.headers["set-cookie"]).toContain("Domain=.pyosh.com");
+  });
+});

--- a/test/routes/auth.proxy.e2e.test.ts
+++ b/test/routes/auth.proxy.e2e.test.ts
@@ -17,6 +17,7 @@ async function createProductionProxyApp(): Promise<FastifyInstance> {
         ...actual.env,
         NODE_ENV: "production" as const,
         SESSION_COOKIE_DOMAIN: ".pyosh.com",
+        TRUSTED_PROXY_RANGES: "172.18.0.10/32",
       },
     };
   });
@@ -77,6 +78,25 @@ describe("Auth Routes Behind HTTPS Proxy", () => {
       headers: {
         "x-forwarded-proto": "https",
         "x-forwarded-for": "1.2.3.4",
+      },
+      payload: {
+        username: TEST_ADMIN_USERNAME,
+        password: TEST_ADMIN_PASSWORD,
+      },
+    });
+
+    expect(response.statusCode).toBe(200);
+    expect(response.headers["set-cookie"]).toBeUndefined();
+  });
+
+  it("ignores forwarded headers from private peers outside the configured allowlist", async () => {
+    const response = await app.inject({
+      method: "POST",
+      url: "/auth/admin/login",
+      remoteAddress: "172.18.0.11",
+      headers: {
+        "x-forwarded-proto": "https",
+        "x-forwarded-for": "10.0.0.5",
       },
       payload: {
         username: TEST_ADMIN_USERNAME,


### PR DESCRIPTION
## Summary

Closes #106

Enable Fastify proxy trust so production requests forwarded by Cloudflare Tunnel are treated as HTTPS and `@fastify/session` emits the secure admin session cookie.

## Changes

| File | Change |
|------|--------|
| `src/app.ts` | Set `trustProxy: true` on the Fastify instance so forwarded HTTPS requests keep secure session cookies enabled |
| `test/routes/auth.proxy.e2e.test.ts` | Add a production-mode auth regression test covering login behind an HTTPS proxy |

