### PR TITLE
fix: document fixed subnet for trusted proxy in docker compose (#108)

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -24,7 +24,15 @@ DB_DTBS=pyosh_blog
 # Session
 SESSION_SECRET=replace-with-long-random-string
 # SESSION_COOKIE_DOMAIN=.pyosh.com
+# 로컬 루프백만 신뢰하는 경우 (기본 예시)
 # TRUSTED_PROXY_RANGES=127.0.0.1/32,::1/128
+#
+# Docker Compose 배포 환경에서 cloudflared가 blog_network 내부에서 접근하는 경우,
+# 단일 컨테이너 IP 대신 네트워크 서브넷 전체를 지정한다.
+# blog_network는 내부 전용(external: true)이므로 서브넷 전체를 신뢰해도 안전하며,
+# 컨테이너 재시작/네트워크 재생성 시 IP가 바뀌어도 재발하지 않는다.
+# 네트워크 생성: docker network create --driver bridge --subnet 172.28.0.0/24 blog_network
+# TRUSTED_PROXY_RANGES=172.28.0.0/24
 
 # OAuth redirects
 LOGIN_SUCCESS_PATH=/auth/success

--- a/.env.example
+++ b/.env.example
@@ -29,7 +29,8 @@ SESSION_SECRET=replace-with-long-random-string
 #
 # Docker Compose 배포 환경에서 cloudflared가 blog_network 내부에서 접근하는 경우,
 # 단일 컨테이너 IP 대신 네트워크 서브넷 전체를 지정한다.
-# blog_network는 내부 전용(external: true)이므로 서브넷 전체를 신뢰해도 안전하며,
+# blog_network는 외부 포트 노출 없이 blog_network에만 붙어 있으므로 서브넷 전체를 신뢰해도 안전하며,
+# (external: true는 compose가 네트워크를 직접 생성하지 않는다는 의미일 뿐 트래픽 격리와 무관)
 # 컨테이너 재시작/네트워크 재생성 시 IP가 바뀌어도 재발하지 않는다.
 # 네트워크 생성: docker network create --driver bridge --subnet 172.28.0.0/24 blog_network
 # TRUSTED_PROXY_RANGES=172.28.0.0/24

--- a/cloudflared/docker-compose.yml
+++ b/cloudflared/docker-compose.yml
@@ -6,6 +6,12 @@
 #   3) "Install connector → Docker" 에서 보여주는 명령의 --token 뒤 긴 문자열 복사
 #   4) 이 파일과 같은 폴더에 .env 파일 만들고 한 줄: TUNNEL_TOKEN=<복사한 토큰>
 #   5) chmod 600 .env
+#   6) blog_network를 고정 서브넷으로 생성 (아직 없는 경우):
+#      docker network create --driver bridge --subnet 172.28.0.0/24 blog_network
+#      이미 생성돼 있다면 서브넷 확인:
+#      docker network inspect blog_network --format '{{range .IPAM.Config}}{{.Subnet}}{{end}}'
+#      서브넷이 다르면 컨테이너를 stop 후 network rm → 위 명령으로 재생성.
+#      서버 .env의 TRUSTED_PROXY_RANGES를 해당 서브넷 CIDR로 설정.
 #
 # 운영:
 #   docker compose up -d        # 시작

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -15,6 +15,7 @@ services:
     networks:
       - blog_network
     # 외부 포트 노출 없음. cloudflared가 blog_network 내부에서 접근.
+    # blog_network 생성 절차는 cloudflared/docker-compose.yml 주석 참고.
 
 networks:
   blog_network:

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "pyosh-blog-be",
-  "version": "1.1.0",
+  "version": "1.1.2",
   "repository": "https://github.com/pyo-sh/pyosh-blog-be.git",
   "license": "MIT",
   "author": "pyo-sh <pygosky@gmail.com>",


### PR DESCRIPTION
## Summary

Closes #108

cloudflared 컨테이너의 Docker 내부 IP가 바뀔 때마다 `TRUSTED_PROXY_RANGES`가 맞지 않아 `X-Forwarded-Proto` 헤더가 삭제되고, 결과적으로 secure 세션 쿠키가 발급되지 않아 관리자 로그인이 실패하는 현상이 재발했다.

단일 IP 대신 `blog_network` 서브넷 전체(CIDR)를 신뢰하고, 해당 서브넷을 고정 생성하도록 운영 절차를 `.env.example`과 compose 주석에 문서화하여 재발을 방지한다.

## Changes

| File | Change |
|------|--------|
| `.env.example` | `TRUSTED_PROXY_RANGES` 설명을 Docker Compose 배포 환경용 서브넷 CIDR 예시(`172.28.0.0/24`)와 운영 가이드 주석으로 보강 |
| `cloudflared/docker-compose.yml` | "사전 준비" 6번 항목: `blog_network` 고정 서브넷 생성 명령과 서브넷 확인·재생성 절차 추가 |
| `docker-compose.yml` | `blog_network` 생성 절차 참조 주석 한 줄 추가 |
| `package.json` | `version` 1.1.0 → 1.1.2 (tag v1.1.1과 파일 불일치 동시 정정) |
