### PR TITLE
fix: repair taxonomy slug generation (#111)

### DIFF
--- a/package.json
+++ b/package.json
@@ -17,6 +17,7 @@
     "db:migrate": "NODE_ENV=development ts-node ./scripts/db-migrate.ts",
     "db:migrate:status": "NODE_ENV=development ts-node ./scripts/db-migration-status.ts",
     "db:admin": "NODE_ENV=development ts-node ./scripts/admin-manager.ts",
+    "slug:repair": "NODE_ENV=development ts-node ./scripts/repair-taxonomy-slugs.ts",
     "pw:create": "ts-node ./scripts/hash-password.ts",
     "tool": "docker compose -f scripts/tools/docker-compose.yml run --rm tool"
   },

--- a/scripts/README.md
+++ b/scripts/README.md
@@ -216,6 +216,43 @@ pnpm db:migrate:status -- --pending-only
 
 ---
 
+## repair-taxonomy-slugs.ts
+
+카테고리/태그의 legacy 빈 slug 또는 `-2` 형태 slug 를 유니코드 slug 또는 `id` fallback 으로 일괄 복구합니다.
+
+### 언제 사용하나
+
+- 과거 버그로 생성된 빈 slug 데이터를 정리할 때
+- 공개 `/categories/...`, `/tags/...` 링크 404 원인을 정리할 때
+
+### 사용법
+
+```bash
+# 기본: dry-run
+pnpm slug:repair
+
+# 실제 반영
+pnpm slug:repair -- --apply
+
+# 특정 리소스만 대상 지정
+pnpm slug:repair -- --target=categories
+pnpm slug:repair -- --target=tags
+```
+
+### 동작 방식
+
+1. 현재 category/tag 테이블을 스캔합니다.
+2. 빈 slug 또는 `-숫자` legacy slug 만 추립니다.
+3. 이름 기반 `generateUnicodeSlug()` 결과를 우선 사용합니다.
+4. 결과가 비면 `id` 기반 fallback slug 를 사용합니다.
+5. `--apply` 가 없으면 변경 예정 내용만 출력합니다.
+
+### 필요 환경변수
+
+`DB_HOST`, `DB_PORT`, `DB_USER`, `DB_PSWD`, `DB_DTBS`
+
+---
+
 ## db-env.ts (헬퍼 모듈)
 
 직접 실행하는 스크립트가 아닌, `db-migrate.ts`와 `db-migration-status.ts`에서 공통으로 사용하는 내부 모듈입니다.

--- a/scripts/repair-taxonomy-slugs.ts
+++ b/scripts/repair-taxonomy-slugs.ts
@@ -1,0 +1,259 @@
+import { drizzle, type MySql2Database } from "drizzle-orm/mysql2";
+import mysql from "mysql2/promise";
+import { eq } from "drizzle-orm";
+import { loadEnv, requireDbEnv } from "./db-env";
+import { categoryTable } from "../src/db/schema/categories";
+import * as schema from "../src/db/schema/index";
+import { tagTable } from "../src/db/schema/tags";
+import {
+  ensureUniqueSlug,
+  generateUnicodeSlug,
+  isBlankSlug,
+  needsLegacySlugRepair,
+} from "../src/shared/slug";
+
+type RepairTarget = "categories" | "tags" | "all";
+
+function parseArgs(argv: string[]) {
+  const options = {
+    dryRun: true,
+    target: "all" as RepairTarget,
+  };
+
+  for (const arg of argv) {
+    if (arg === "--apply") {
+      options.dryRun = false;
+      continue;
+    }
+
+    if (arg === "--dry-run") {
+      options.dryRun = true;
+      continue;
+    }
+
+    if (arg.startsWith("--target=")) {
+      const value = arg.slice("--target=".length) as RepairTarget;
+      if (value === "categories" || value === "tags" || value === "all") {
+        options.target = value;
+        continue;
+      }
+    }
+
+    throw new Error(
+      'Usage: pnpm ts-node ./scripts/repair-taxonomy-slugs.ts [--dry-run] [--apply] [--target=categories|tags|all]',
+    );
+  }
+
+  return options;
+}
+
+async function main() {
+  const options = parseArgs(process.argv.slice(2));
+
+  loadEnv();
+  const dbEnv = requireDbEnv("repair-taxonomy-slugs");
+  const pool = mysql.createPool({
+    host: dbEnv.host,
+    port: dbEnv.port,
+    user: dbEnv.user,
+    password: dbEnv.password,
+    database: dbEnv.database,
+  });
+  const db = drizzle(pool, { schema, mode: "default" });
+
+  try {
+    const categoryPlans =
+      options.target === "tags"
+        ? []
+        : await buildRepairPlans({
+            rows: await db
+              .select({
+                id: categoryTable.id,
+                name: categoryTable.name,
+                slug: categoryTable.slug,
+              })
+              .from(categoryTable),
+            resolveSlug: async (id, name) =>
+              await resolveCategorySlug(db, id, name, id),
+          });
+
+    const tagPlans =
+      options.target === "categories"
+        ? []
+        : await buildRepairPlans({
+            rows: await db
+              .select({
+                id: tagTable.id,
+                name: tagTable.name,
+                slug: tagTable.slug,
+              })
+              .from(tagTable),
+            resolveSlug: async (id, name) =>
+              await resolveTagSlug(db, id, name, id),
+          });
+
+    if (categoryPlans.length === 0 && tagPlans.length === 0) {
+      console.log("[repair-taxonomy-slugs] No legacy slugs found.");
+      return;
+    }
+
+    for (const plan of categoryPlans) {
+      console.log(
+        `[categories] ${plan.id}: "${plan.slug}" -> "${plan.nextSlug}" (${plan.name})`,
+      );
+    }
+
+    for (const plan of tagPlans) {
+      console.log(
+        `[tags] ${plan.id}: "${plan.slug}" -> "${plan.nextSlug}" (${plan.name})`,
+      );
+    }
+
+    if (options.dryRun) {
+      console.log("[repair-taxonomy-slugs] Dry run complete. No changes applied.");
+      return;
+    }
+
+    for (const plan of categoryPlans) {
+      await db
+        .update(categoryTable)
+        .set({ slug: plan.nextSlug })
+        .where(eq(categoryTable.id, plan.id));
+    }
+
+    for (const plan of tagPlans) {
+      await db.update(tagTable).set({ slug: plan.nextSlug }).where(eq(tagTable.id, plan.id));
+    }
+
+    console.log(
+      `[repair-taxonomy-slugs] Applied ${categoryPlans.length + tagPlans.length} slug repairs.`,
+    );
+  } finally {
+    await pool.end();
+  }
+}
+
+async function buildRepairPlans(input: {
+  rows: Array<{ id: number; name: string; slug: string }>;
+  resolveSlug: (id: number, name: string) => Promise<string>;
+}) {
+  const plans: Array<{ id: number; name: string; slug: string; nextSlug: string }> = [];
+
+  for (const row of input.rows) {
+    if (!needsLegacySlugRepair(row.slug)) {
+      continue;
+    }
+
+    plans.push({
+      id: row.id,
+      name: row.name,
+      slug: row.slug,
+      nextSlug: await input.resolveSlug(row.id, row.name),
+    });
+  }
+
+  return plans;
+}
+
+async function resolveCategorySlug(
+  db: MySql2Database<typeof schema>,
+  categoryId: number,
+  name: string,
+  excludeId?: number,
+) {
+  const preferredSlug = generateUnicodeSlug(name);
+
+  if (isBlankSlug(preferredSlug)) {
+    return await ensureUniqueSlug(String(categoryId), async (checkSlug) => {
+      const [existing] = await db
+        .select({ id: categoryTable.id })
+        .from(categoryTable)
+        .where(eq(categoryTable.slug, checkSlug))
+        .limit(1);
+
+      if (!existing) {
+        return false;
+      }
+
+      return excludeId === undefined || existing.id !== excludeId;
+    });
+  }
+
+  const [existing] = await db
+    .select({ id: categoryTable.id })
+    .from(categoryTable)
+    .where(eq(categoryTable.slug, preferredSlug))
+    .limit(1);
+
+  if (!existing || existing.id === excludeId) {
+    return preferredSlug;
+  }
+
+  return await ensureUniqueSlug(String(categoryId), async (checkSlug) => {
+    const [duplicate] = await db
+      .select({ id: categoryTable.id })
+      .from(categoryTable)
+      .where(eq(categoryTable.slug, checkSlug))
+      .limit(1);
+
+    if (!duplicate) {
+      return false;
+    }
+
+    return excludeId === undefined || duplicate.id !== excludeId;
+  });
+}
+
+async function resolveTagSlug(
+  db: MySql2Database<typeof schema>,
+  tagId: number,
+  name: string,
+  excludeId?: number,
+) {
+  const preferredSlug = generateUnicodeSlug(name);
+
+  if (isBlankSlug(preferredSlug)) {
+    return await ensureUniqueSlug(String(tagId), async (checkSlug) => {
+      const [existing] = await db
+        .select({ id: tagTable.id })
+        .from(tagTable)
+        .where(eq(tagTable.slug, checkSlug))
+        .limit(1);
+
+      if (!existing) {
+        return false;
+      }
+
+      return excludeId === undefined || existing.id !== excludeId;
+    });
+  }
+
+  const [existing] = await db
+    .select({ id: tagTable.id })
+    .from(tagTable)
+    .where(eq(tagTable.slug, preferredSlug))
+    .limit(1);
+
+  if (!existing || existing.id === excludeId) {
+    return preferredSlug;
+  }
+
+  return await ensureUniqueSlug(String(tagId), async (checkSlug) => {
+    const [duplicate] = await db
+      .select({ id: tagTable.id })
+      .from(tagTable)
+      .where(eq(tagTable.slug, checkSlug))
+      .limit(1);
+
+    if (!duplicate) {
+      return false;
+    }
+
+    return excludeId === undefined || duplicate.id !== excludeId;
+  });
+}
+
+void main().catch((error) => {
+  console.error("[repair-taxonomy-slugs]", error);
+  process.exitCode = 1;
+});

--- a/scripts/repair-taxonomy-slugs.ts
+++ b/scripts/repair-taxonomy-slugs.ts
@@ -1,4 +1,4 @@
-import { drizzle, type MySql2Database } from "drizzle-orm/mysql2";
+import { drizzle } from "drizzle-orm/mysql2";
 import mysql from "mysql2/promise";
 import { eq } from "drizzle-orm";
 import { loadEnv, requireDbEnv } from "./db-env";
@@ -62,35 +62,33 @@ async function main() {
   const db = drizzle(pool, { schema, mode: "default" });
 
   try {
-    const categoryPlans =
+    const categoryRows =
       options.target === "tags"
         ? []
-        : await buildRepairPlans({
-            rows: await db
-              .select({
-                id: categoryTable.id,
-                name: categoryTable.name,
-                slug: categoryTable.slug,
-              })
-              .from(categoryTable),
-            resolveSlug: async (id, name) =>
-              await resolveCategorySlug(db, id, name, id),
-          });
+        : await db
+            .select({
+              id: categoryTable.id,
+              name: categoryTable.name,
+              slug: categoryTable.slug,
+            })
+            .from(categoryTable);
 
-    const tagPlans =
+    const tagRows =
       options.target === "categories"
         ? []
-        : await buildRepairPlans({
-            rows: await db
-              .select({
-                id: tagTable.id,
-                name: tagTable.name,
-                slug: tagTable.slug,
-              })
-              .from(tagTable),
-            resolveSlug: async (id, name) =>
-              await resolveTagSlug(db, id, name, id),
-          });
+        : await db
+            .select({
+              id: tagTable.id,
+              name: tagTable.name,
+              slug: tagTable.slug,
+            })
+            .from(tagTable);
+
+    const categoryPlans = await buildRepairPlans(
+      categoryRows,
+      resolveCategorySlug,
+    );
+    const tagPlans = await buildRepairPlans(tagRows, resolveTagSlug);
 
     if (categoryPlans.length === 0 && tagPlans.length === 0) {
       console.log("[repair-taxonomy-slugs] No legacy slugs found.");
@@ -114,16 +112,21 @@ async function main() {
       return;
     }
 
-    for (const plan of categoryPlans) {
-      await db
-        .update(categoryTable)
-        .set({ slug: plan.nextSlug })
-        .where(eq(categoryTable.id, plan.id));
-    }
+    await db.transaction(async (tx) => {
+      for (const plan of categoryPlans) {
+        await tx
+          .update(categoryTable)
+          .set({ slug: plan.nextSlug })
+          .where(eq(categoryTable.id, plan.id));
+      }
 
-    for (const plan of tagPlans) {
-      await db.update(tagTable).set({ slug: plan.nextSlug }).where(eq(tagTable.id, plan.id));
-    }
+      for (const plan of tagPlans) {
+        await tx
+          .update(tagTable)
+          .set({ slug: plan.nextSlug })
+          .where(eq(tagTable.id, plan.id));
+      }
+    });
 
     console.log(
       `[repair-taxonomy-slugs] Applied ${categoryPlans.length + tagPlans.length} slug repairs.`,
@@ -133,124 +136,87 @@ async function main() {
   }
 }
 
-async function buildRepairPlans(input: {
-  rows: Array<{ id: number; name: string; slug: string }>;
-  resolveSlug: (id: number, name: string) => Promise<string>;
-}) {
+async function buildRepairPlans(
+  rows: Array<{ id: number; name: string; slug: string }>,
+  resolveSlug: (input: {
+    id: number;
+    name: string;
+    occupiedSlugs: Set<string>;
+  }) => Promise<string>,
+) {
   const plans: Array<{ id: number; name: string; slug: string; nextSlug: string }> = [];
+  const occupiedSlugs = new Set(
+    rows.filter((row) => !needsLegacySlugRepair(row.slug)).map((row) => row.slug),
+  );
 
-  for (const row of input.rows) {
+  for (const row of rows) {
     if (!needsLegacySlugRepair(row.slug)) {
       continue;
     }
 
+    const nextSlug = await resolveSlug({
+      id: row.id,
+      name: row.name,
+      occupiedSlugs,
+    });
     plans.push({
       id: row.id,
       name: row.name,
       slug: row.slug,
-      nextSlug: await input.resolveSlug(row.id, row.name),
+      nextSlug,
     });
+    occupiedSlugs.add(nextSlug);
   }
 
   return plans;
 }
 
-async function resolveCategorySlug(
-  db: MySql2Database<typeof schema>,
-  categoryId: number,
-  name: string,
-  excludeId?: number,
-) {
-  const preferredSlug = generateUnicodeSlug(name);
+async function resolveCategorySlug(input: {
+  id: number;
+  name: string;
+  occupiedSlugs: Set<string>;
+}) {
+  const preferredSlug = generateUnicodeSlug(input.name);
 
   if (isBlankSlug(preferredSlug)) {
-    return await ensureUniqueSlug(String(categoryId), async (checkSlug) => {
-      const [existing] = await db
-        .select({ id: categoryTable.id })
-        .from(categoryTable)
-        .where(eq(categoryTable.slug, checkSlug))
-        .limit(1);
-
-      if (!existing) {
-        return false;
-      }
-
-      return excludeId === undefined || existing.id !== excludeId;
-    });
+    return await ensureUniqueSlug(
+      String(input.id),
+      async (checkSlug) => input.occupiedSlugs.has(checkSlug),
+    );
   }
 
-  const [existing] = await db
-    .select({ id: categoryTable.id })
-    .from(categoryTable)
-    .where(eq(categoryTable.slug, preferredSlug))
-    .limit(1);
-
-  if (!existing || existing.id === excludeId) {
+  if (!input.occupiedSlugs.has(preferredSlug)) {
     return preferredSlug;
   }
 
-  return await ensureUniqueSlug(String(categoryId), async (checkSlug) => {
-    const [duplicate] = await db
-      .select({ id: categoryTable.id })
-      .from(categoryTable)
-      .where(eq(categoryTable.slug, checkSlug))
-      .limit(1);
-
-    if (!duplicate) {
-      return false;
-    }
-
-    return excludeId === undefined || duplicate.id !== excludeId;
-  });
+  return await ensureUniqueSlug(
+    preferredSlug,
+    async (checkSlug) => input.occupiedSlugs.has(checkSlug),
+  );
 }
 
-async function resolveTagSlug(
-  db: MySql2Database<typeof schema>,
-  tagId: number,
-  name: string,
-  excludeId?: number,
-) {
-  const preferredSlug = generateUnicodeSlug(name);
+async function resolveTagSlug(input: {
+  id: number;
+  name: string;
+  occupiedSlugs: Set<string>;
+}) {
+  const preferredSlug = generateUnicodeSlug(input.name);
 
   if (isBlankSlug(preferredSlug)) {
-    return await ensureUniqueSlug(String(tagId), async (checkSlug) => {
-      const [existing] = await db
-        .select({ id: tagTable.id })
-        .from(tagTable)
-        .where(eq(tagTable.slug, checkSlug))
-        .limit(1);
-
-      if (!existing) {
-        return false;
-      }
-
-      return excludeId === undefined || existing.id !== excludeId;
-    });
+    return await ensureUniqueSlug(
+      String(input.id),
+      async (checkSlug) => input.occupiedSlugs.has(checkSlug),
+    );
   }
 
-  const [existing] = await db
-    .select({ id: tagTable.id })
-    .from(tagTable)
-    .where(eq(tagTable.slug, preferredSlug))
-    .limit(1);
-
-  if (!existing || existing.id === excludeId) {
+  if (!input.occupiedSlugs.has(preferredSlug)) {
     return preferredSlug;
   }
 
-  return await ensureUniqueSlug(String(tagId), async (checkSlug) => {
-    const [duplicate] = await db
-      .select({ id: tagTable.id })
-      .from(tagTable)
-      .where(eq(tagTable.slug, checkSlug))
-      .limit(1);
-
-    if (!duplicate) {
-      return false;
-    }
-
-    return excludeId === undefined || duplicate.id !== excludeId;
-  });
+  return await ensureUniqueSlug(
+    String(input.id),
+    async (checkSlug) => input.occupiedSlugs.has(checkSlug),
+  );
 }
 
 void main().catch((error) => {

--- a/src/routes/categories/category.route.ts
+++ b/src/routes/categories/category.route.ts
@@ -102,9 +102,10 @@ export function createCategoryRoute(
         },
       },
       async (request, reply) => {
-        const { name, parentId, isVisible } = request.body;
+        const { name, slug, parentId, isVisible } = request.body;
         const category = await categoryService.createCategory({
           name,
+          slug,
           parentId,
           isVisible,
         });
@@ -176,11 +177,12 @@ export function createCategoryRoute(
       },
       async (request, reply) => {
         const { id } = request.params;
-        const { name, parentId, sortOrder, isVisible } = request.body;
+        const { name, slug, parentId, sortOrder, isVisible } = request.body;
 
         const category = await categoryService.updateCategory({
           id,
           name,
+          slug,
           parentId,
           sortOrder,
           isVisible,

--- a/src/routes/categories/category.schema.ts
+++ b/src/routes/categories/category.schema.ts
@@ -41,6 +41,12 @@ export const CategoryDeleteQuerySchema = z
  */
 export const CategoryCreateBodySchema = z.object({
   name: z.string().min(1).max(50).describe("카테고리 이름 (최대 50자)"),
+  slug: z
+    .string()
+    .min(1)
+    .max(100)
+    .optional()
+    .describe("카테고리 수동 슬러그 (선택)"),
   parentId: z
     .number()
     .int()
@@ -58,6 +64,12 @@ export const CategoryUpdateBodySchema = z.object({
     .max(50)
     .optional()
     .describe("카테고리 이름 (최대 50자)"),
+  slug: z
+    .string()
+    .min(1)
+    .max(100)
+    .optional()
+    .describe("카테고리 수동 슬러그 (선택)"),
   parentId: z
     .number()
     .int()

--- a/src/routes/categories/category.service.ts
+++ b/src/routes/categories/category.service.ts
@@ -8,13 +8,19 @@ import {
 import * as schema from "@src/db/schema/index";
 import { postTable } from "@src/db/schema/posts";
 import { HttpError } from "@src/errors/http-error";
-import { generateSlug, ensureUniqueSlug } from "@src/shared/slug";
+import {
+  ensureUniqueSlug,
+  generateUnicodeSlug,
+  isBlankSlug,
+  needsLegacySlugRepair,
+} from "@src/shared/slug";
 
 /**
  * Category 생성 파라미터
  */
 export interface CategoryCreateArgs {
   name: string;
+  slug?: string;
   parentId?: number | null;
   isVisible?: boolean;
 }
@@ -25,6 +31,7 @@ export interface CategoryCreateArgs {
 export interface CategoryUpdateArgs {
   id: number;
   name?: string;
+  slug?: string;
   parentId?: number | null;
   sortOrder?: number;
   isVisible?: boolean;
@@ -71,75 +78,72 @@ export class CategoryService {
 
   /**
    * 카테고리 생성
-   * - slug 자동 생성 및 중복 체크
+   * - 유니코드 slug 자동 생성 및 중복/legacy 대응
    * - 부모 카테고리 존재 확인
    * - sort_order 자동 부여 (같은 부모 아래 최대값 + 1)
    */
   async createCategory(data: CategoryCreateArgs): Promise<CategoryWithCounts> {
-    // 1. slug 생성
-    let slug = generateSlug(data.name);
+    return await this.db.transaction(async (tx) => {
+      if (data.parentId) {
+        const [parent] = await tx
+          .select()
+          .from(categoryTable)
+          .where(eq(categoryTable.id, data.parentId))
+          .limit(1);
 
-    // 2. slug 중복 체크 및 고유 slug 생성
-    slug = await ensureUniqueSlug(slug, async (checkSlug) => {
-      const [existing] = await this.db
-        .select()
-        .from(categoryTable)
-        .where(eq(categoryTable.slug, checkSlug))
-        .limit(1);
-
-      return Boolean(existing);
-    });
-
-    // 3. parent_id가 있으면 부모 카테고리 존재 확인
-    if (data.parentId) {
-      const [parent] = await this.db
-        .select()
-        .from(categoryTable)
-        .where(eq(categoryTable.id, data.parentId))
-        .limit(1);
-
-      if (!parent) {
-        throw HttpError.badRequest("Parent category not found.");
+        if (!parent) {
+          throw HttpError.badRequest("Parent category not found.");
+        }
       }
-    }
 
-    // 4. 같은 부모 아래 최대 sort_order 조회하여 +1
-    const [maxOrder] = await this.db
-      .select({
-        max: sql<number>`COALESCE(MAX(${categoryTable.sortOrder}), 0)`,
-      })
-      .from(categoryTable)
-      .where(
-        data.parentId
-          ? eq(categoryTable.parentId, data.parentId)
-          : isNull(categoryTable.parentId),
+      const [maxOrder] = await tx
+        .select({
+          max: sql<number>`COALESCE(MAX(${categoryTable.sortOrder}), 0)`,
+        })
+        .from(categoryTable)
+        .where(
+          data.parentId
+            ? eq(categoryTable.parentId, data.parentId)
+            : isNull(categoryTable.parentId),
+        );
+
+      const sortOrder = (maxOrder?.max ?? 0) + 1;
+      const newCategory: NewCategory = {
+        name: data.name,
+        slug: this.buildPendingSlug(),
+        parentId: data.parentId ?? null,
+        sortOrder,
+        isVisible: data.isVisible ?? true,
+      };
+
+      const [result] = await tx.insert(categoryTable).values(newCategory);
+      const categoryId = Number(result.insertId);
+      const resolvedSlug = await this.resolveCategorySlug(
+        tx,
+        data.name,
+        categoryId,
+        data.slug,
       );
 
-    const sortOrder = (maxOrder?.max ?? 0) + 1;
+      if (resolvedSlug !== newCategory.slug) {
+        await tx
+          .update(categoryTable)
+          .set({ slug: resolvedSlug })
+          .where(eq(categoryTable.id, categoryId));
+      }
 
-    // 5. 카테고리 생성
-    const newCategory: NewCategory = {
-      name: data.name,
-      slug,
-      parentId: data.parentId ?? null,
-      sortOrder,
-      isVisible: data.isVisible ?? true,
-    };
+      const [category] = await tx
+        .select()
+        .from(categoryTable)
+        .where(eq(categoryTable.id, categoryId))
+        .limit(1);
 
-    const [result] = await this.db.insert(categoryTable).values(newCategory);
+      if (!category) {
+        throw HttpError.internal("Failed to create category.");
+      }
 
-    // 6. 생성된 카테고리 조회
-    const [category] = await this.db
-      .select()
-      .from(categoryTable)
-      .where(eq(categoryTable.id, Number(result.insertId)))
-      .limit(1);
-
-    if (!category) {
-      throw HttpError.internal("Failed to create category.");
-    }
-
-    return { ...category, publishedPostCount: 0, totalPostCount: 0 };
+      return { ...category, publishedPostCount: 0, totalPostCount: 0 };
+    });
   }
 
   /**
@@ -217,95 +221,164 @@ export class CategoryService {
   /**
    * 카테고리 수정
    * - parent_id 변경 시 순환 참조 방지
-   * - name 변경 시 slug는 그대로 유지 (선택적으로 재생성 가능)
+   * - slug 수동 override 또는 legacy slug 복구 지원
    */
   async updateCategory(args: CategoryUpdateArgs): Promise<CategoryWithCounts> {
-    const { id, name, parentId, sortOrder, isVisible } = args;
+    const { id, name, slug, parentId, sortOrder, isVisible } = args;
 
-    // 1. 카테고리 존재 확인
-    const [existing] = await this.db
-      .select()
-      .from(categoryTable)
-      .where(eq(categoryTable.id, id))
-      .limit(1);
+    return await this.db.transaction(async (tx) => {
+      const [existing] = await tx
+        .select()
+        .from(categoryTable)
+        .where(eq(categoryTable.id, id))
+        .limit(1);
 
-    if (!existing) {
-      throw HttpError.notFound("Category not found.");
-    }
-
-    // 2. parent_id 변경 시 순환 참조 방지 체크
-    if (parentId !== undefined && parentId !== null) {
-      // 자기 자신을 부모로 설정하는 경우
-      if (parentId === id) {
-        throw HttpError.badRequest("A category cannot be its own parent.");
+      if (!existing) {
+        throw HttpError.notFound("Category not found.");
       }
 
-      // 자신의 하위 카테고리를 부모로 설정하는 경우 체크
-      const isDescendant = await this.isDescendantOf(id, parentId);
-      if (isDescendant) {
-        throw HttpError.badRequest(
-          "Cannot set a descendant category as parent.",
+      if (parentId !== undefined && parentId !== null) {
+        if (parentId === id) {
+          throw HttpError.badRequest("A category cannot be its own parent.");
+        }
+
+        const isDescendant = await this.isDescendantOf(id, parentId);
+        if (isDescendant) {
+          throw HttpError.badRequest(
+            "Cannot set a descendant category as parent.",
+          );
+        }
+
+        const [parent] = await tx
+          .select()
+          .from(categoryTable)
+          .where(eq(categoryTable.id, parentId))
+          .limit(1);
+
+        if (!parent) {
+          throw HttpError.badRequest("Parent category not found.");
+        }
+      }
+
+      const updates: Partial<NewCategory> = {};
+      if (name !== undefined) {
+        updates.name = name;
+      }
+      if (parentId !== undefined) {
+        updates.parentId = parentId;
+      }
+      if (sortOrder !== undefined) {
+        updates.sortOrder = sortOrder;
+      }
+      if (isVisible !== undefined) {
+        updates.isVisible = isVisible;
+      }
+
+      if (slug !== undefined || needsLegacySlugRepair(existing.slug)) {
+        updates.slug = await this.resolveCategorySlug(
+          tx,
+          name ?? existing.name,
+          id,
+          slug,
+          id,
         );
       }
 
-      // 부모 카테고리 존재 확인
-      const [parent] = await this.db
+      await tx.update(categoryTable).set(updates).where(eq(categoryTable.id, id));
+
+      const [updated] = await tx
         .select()
         .from(categoryTable)
-        .where(eq(categoryTable.id, parentId))
+        .where(eq(categoryTable.id, id))
         .limit(1);
 
-      if (!parent) {
-        throw HttpError.badRequest("Parent category not found.");
+      if (!updated) {
+        throw HttpError.internal("Failed to update category.");
       }
+
+      const [counts] = await tx
+        .select({
+          publishedPostCount: sql<number>`SUM(CASE WHEN ${postTable.status} = 'published' AND ${postTable.visibility} = 'public' AND ${postTable.deletedAt} IS NULL THEN 1 ELSE 0 END)`,
+          totalPostCount: sql<number>`SUM(CASE WHEN ${postTable.deletedAt} IS NULL THEN 1 ELSE 0 END)`,
+        })
+        .from(postTable)
+        .where(eq(postTable.categoryId, id));
+
+      return {
+        ...updated,
+        publishedPostCount: Number(counts?.publishedPostCount ?? 0),
+        totalPostCount: Number(counts?.totalPostCount ?? 0),
+      };
+    });
+  }
+
+  private buildPendingSlug(): string {
+    return `__pending__${Date.now()}-${Math.random().toString(36).slice(2, 10)}`;
+  }
+
+  private async resolveCategorySlug(
+    tx: MySql2Database<typeof schema>,
+    name: string,
+    categoryId: number,
+    requestedSlug?: string,
+    excludeId?: number,
+  ): Promise<string> {
+    const preferredSlug =
+      requestedSlug !== undefined
+        ? this.normalizeRequestedSlug(requestedSlug)
+        : generateUnicodeSlug(name);
+
+    if (requestedSlug === undefined && isBlankSlug(preferredSlug)) {
+      return await this.resolveFallbackSlug(tx, categoryId, excludeId);
     }
 
-    // 3. 변경사항 적용
-    const updates: Partial<Category> = {};
-    if (name !== undefined) {
-      updates.name = name;
-      // slug는 유지 (필요시 재생성 옵션 추가 가능)
-    }
-    if (parentId !== undefined) {
-      updates.parentId = parentId;
-    }
-    if (sortOrder !== undefined) {
-      updates.sortOrder = sortOrder;
-    }
-    if (isVisible !== undefined) {
-      updates.isVisible = isVisible;
-    }
-
-    await this.db
-      .update(categoryTable)
-      .set(updates)
-      .where(eq(categoryTable.id, id));
-
-    // 4. 업데이트된 카테고리 조회
-    const [updated] = await this.db
-      .select()
+    const existing = await tx
+      .select({ id: categoryTable.id })
       .from(categoryTable)
-      .where(eq(categoryTable.id, id))
+      .where(eq(categoryTable.slug, preferredSlug))
       .limit(1);
 
-    if (!updated) {
-      throw HttpError.internal("Failed to update category.");
+    if (existing.length === 0 || existing[0]?.id === excludeId) {
+      return preferredSlug;
     }
 
-    // 5. 게시글 카운트 조회
-    const [counts] = await this.db
-      .select({
-        publishedPostCount: sql<number>`SUM(CASE WHEN ${postTable.status} = 'published' AND ${postTable.visibility} = 'public' AND ${postTable.deletedAt} IS NULL THEN 1 ELSE 0 END)`,
-        totalPostCount: sql<number>`SUM(CASE WHEN ${postTable.deletedAt} IS NULL THEN 1 ELSE 0 END)`,
-      })
-      .from(postTable)
-      .where(eq(postTable.categoryId, id));
+    if (requestedSlug !== undefined) {
+      throw HttpError.badRequest("Slug already exists.");
+    }
 
-    return {
-      ...updated,
-      publishedPostCount: Number(counts?.publishedPostCount ?? 0),
-      totalPostCount: Number(counts?.totalPostCount ?? 0),
-    };
+    return await this.resolveFallbackSlug(tx, categoryId, excludeId);
+  }
+
+  private normalizeRequestedSlug(slug: string): string {
+    const normalizedSlug = generateUnicodeSlug(slug);
+
+    if (isBlankSlug(normalizedSlug)) {
+      throw HttpError.badRequest("Slug cannot be blank after normalization.");
+    }
+
+    return normalizedSlug;
+  }
+
+  private async resolveFallbackSlug(
+    tx: MySql2Database<typeof schema>,
+    categoryId: number,
+    excludeId?: number,
+  ): Promise<string> {
+    const baseSlug = String(categoryId);
+
+    return await ensureUniqueSlug(baseSlug, async (checkSlug) => {
+      const existing = await tx
+        .select({ id: categoryTable.id })
+        .from(categoryTable)
+        .where(eq(categoryTable.slug, checkSlug))
+        .limit(1);
+
+      if (existing.length === 0) {
+        return false;
+      }
+
+      return excludeId === undefined || existing[0]?.id !== excludeId;
+    });
   }
 
   /**

--- a/src/routes/categories/category.service.ts
+++ b/src/routes/categories/category.service.ts
@@ -346,7 +346,19 @@ export class CategoryService {
       throw HttpError.badRequest("Slug already exists.");
     }
 
-    return await this.resolveFallbackSlug(tx, categoryId, excludeId);
+    return await ensureUniqueSlug(preferredSlug, async (checkSlug) => {
+      const duplicate = await tx
+        .select({ id: categoryTable.id })
+        .from(categoryTable)
+        .where(eq(categoryTable.slug, checkSlug))
+        .limit(1);
+
+      if (duplicate.length === 0) {
+        return false;
+      }
+
+      return excludeId === undefined || duplicate[0]?.id !== excludeId;
+    });
   }
 
   private normalizeRequestedSlug(slug: string): string {

--- a/src/routes/categories/category.service.ts
+++ b/src/routes/categories/category.service.ts
@@ -118,19 +118,12 @@ export class CategoryService {
 
       const [result] = await tx.insert(categoryTable).values(newCategory);
       const categoryId = Number(result.insertId);
-      const resolvedSlug = await this.resolveCategorySlug(
+      await this.finalizeCategorySlug(
         tx,
-        data.name,
         categoryId,
+        data.name,
         data.slug,
       );
-
-      if (resolvedSlug !== newCategory.slug) {
-        await tx
-          .update(categoryTable)
-          .set({ slug: resolvedSlug })
-          .where(eq(categoryTable.id, categoryId));
-      }
 
       const [category] = await tx
         .select()
@@ -275,10 +268,10 @@ export class CategoryService {
       }
 
       if (slug !== undefined || needsLegacySlugRepair(existing.slug)) {
-        updates.slug = await this.resolveCategorySlug(
+        updates.slug = await this.finalizeCategorySlug(
           tx,
-          name ?? existing.name,
           id,
+          name ?? existing.name,
           slug,
           id,
         );
@@ -391,6 +384,52 @@ export class CategoryService {
 
       return excludeId === undefined || existing[0]?.id !== excludeId;
     });
+  }
+
+  private async finalizeCategorySlug(
+    tx: MySql2Database<typeof schema>,
+    categoryId: number,
+    name: string,
+    requestedSlug?: string,
+    excludeId?: number,
+  ): Promise<string> {
+    for (let attempt = 0; attempt < 5; attempt++) {
+      const resolvedSlug = await this.resolveCategorySlug(
+        tx,
+        name,
+        categoryId,
+        requestedSlug,
+        excludeId,
+      );
+
+      try {
+        await tx
+          .update(categoryTable)
+          .set({ slug: resolvedSlug })
+          .where(eq(categoryTable.id, categoryId));
+
+        return resolvedSlug;
+      } catch (error) {
+        if (!this.isDuplicateEntry(error)) {
+          throw error;
+        }
+
+        if (requestedSlug !== undefined) {
+          throw HttpError.badRequest("Slug already exists.");
+        }
+      }
+    }
+
+    throw HttpError.internal("Failed to finalize category slug.");
+  }
+
+  private isDuplicateEntry(error: unknown): error is { code: string } {
+    return (
+      typeof error === "object" &&
+      error !== null &&
+      "code" in error &&
+      (error as { code?: string }).code === "ER_DUP_ENTRY"
+    );
   }
 
   /**

--- a/src/routes/posts/post.service.ts
+++ b/src/routes/posts/post.service.ts
@@ -32,6 +32,7 @@ import {
   ensureUniqueSlug,
   generateUnicodeSlug,
   isBlankSlug,
+  needsLegacySlugRepair,
 } from "@src/shared/slug";
 
 const MAX_PINNED_POSTS = 5;
@@ -73,14 +74,6 @@ function normalizeSummary(summary: string | null | undefined) {
   const trimmed = summary?.trim();
 
   return trimmed ? trimmed : null;
-}
-
-function needsLegacySlugRepair(slug: string | null | undefined) {
-  if (isBlankSlug(slug)) {
-    return true;
-  }
-
-  return /^-[0-9]+$/.test(slug.trim());
 }
 
 function resolvePublishedSummary(input: {

--- a/src/routes/tags/tag.service.ts
+++ b/src/routes/tags/tag.service.ts
@@ -62,9 +62,10 @@ export class TagService {
 
     // 4. 새 태그 일괄 생성
     if (newNames.length > 0) {
-      const createdTags = await Promise.all(
-        newNames.map(async (name) => await this.createTag(name)),
-      );
+      const createdTags: Tag[] = [];
+      for (const name of newNames) {
+        createdTags.push(await this.createTag(name));
+      }
 
       const tagsByName = new Map(
         [...repairedExistingTags, ...createdTags].map((tag) => [tag.name, tag]),

--- a/src/routes/tags/tag.service.ts
+++ b/src/routes/tags/tag.service.ts
@@ -190,14 +190,7 @@ export class TagService {
 
         const [result] = await tx.insert(tagTable).values(newTag);
         const tagId = Number(result.insertId);
-        const resolvedSlug = await this.resolveTagSlug(tx, name, tagId);
-
-        if (resolvedSlug !== newTag.slug) {
-          await tx
-            .update(tagTable)
-            .set({ slug: resolvedSlug })
-            .where(eq(tagTable.id, tagId));
-        }
+        await this.finalizeTagSlug(tx, tagId, name);
 
         const [tag] = await tx
           .select()
@@ -232,9 +225,7 @@ export class TagService {
 
   private async repairTagSlug(id: number, name: string): Promise<Tag> {
     return await this.db.transaction(async (tx) => {
-      const resolvedSlug = await this.resolveTagSlug(tx, name, id, id);
-
-      await tx.update(tagTable).set({ slug: resolvedSlug }).where(eq(tagTable.id, id));
+      await this.finalizeTagSlug(tx, id, name, id);
 
       const [updated] = await tx
         .select()
@@ -299,6 +290,29 @@ export class TagService {
 
       return excludeId === undefined || existing[0]?.id !== excludeId;
     });
+  }
+
+  private async finalizeTagSlug(
+    tx: MySql2Database<typeof schema>,
+    tagId: number,
+    name: string,
+    excludeId?: number,
+  ): Promise<string> {
+    for (let attempt = 0; attempt < 5; attempt++) {
+      const resolvedSlug = await this.resolveTagSlug(tx, name, tagId, excludeId);
+
+      try {
+        await tx.update(tagTable).set({ slug: resolvedSlug }).where(eq(tagTable.id, tagId));
+
+        return resolvedSlug;
+      } catch (error) {
+        if (!this.isDuplicateEntry(error)) {
+          throw error;
+        }
+      }
+    }
+
+    throw HttpError.internal("Failed to finalize tag slug.");
   }
 
   private isDuplicateEntry(error: unknown): error is { code: string } {

--- a/src/routes/tags/tag.service.ts
+++ b/src/routes/tags/tag.service.ts
@@ -12,10 +12,16 @@ import { MySql2Database } from "drizzle-orm/mysql2";
 import { z } from "zod";
 import { TagWithPostCountSchema } from "./tag.schema";
 import * as schema from "@src/db/schema/index";
+import { HttpError } from "@src/errors/http-error";
 import { postTagTable } from "@src/db/schema/post-tags";
 import { postTable } from "@src/db/schema/posts";
-import { tagTable, NewTag } from "@src/db/schema/tags";
-import { generateSlug } from "@src/shared/slug";
+import { Tag, tagTable, NewTag } from "@src/db/schema/tags";
+import {
+  ensureUniqueSlug,
+  generateUnicodeSlug,
+  isBlankSlug,
+  needsLegacySlugRepair,
+} from "@src/shared/slug";
 
 /**
  * Tag Service
@@ -48,31 +54,29 @@ export class TagService {
       .from(tagTable)
       .where(inArray(tagTable.name, normalizedNames));
 
+    const repairedExistingTags = await this.repairLegacyTags(existingTags);
+
     // 3. 존재하지 않는 이름들 추출
-    const existingNames = new Set(existingTags.map((tag) => tag.name));
+    const existingNames = new Set(repairedExistingTags.map((tag) => tag.name));
     const newNames = normalizedNames.filter((name) => !existingNames.has(name));
 
     // 4. 새 태그 일괄 생성
     if (newNames.length > 0) {
-      const newTags: NewTag[] = newNames.map((name) => ({
-        name,
-        slug: generateSlug(name),
-      }));
+      const createdTags = await Promise.all(
+        newNames.map(async (name) => await this.createTag(name)),
+      );
 
-      await this.db.insert(tagTable).values(newTags);
+      const tagsByName = new Map(
+        [...repairedExistingTags, ...createdTags].map((tag) => [tag.name, tag]),
+      );
 
-      // 새로 생성된 태그 조회
-      const createdTags = await this.db
-        .select()
-        .from(tagTable)
-        .where(inArray(tagTable.name, newNames));
-
-      // 5. 전체 태그 ID 배열 반환
-      return [...existingTags, ...createdTags].map((tag) => tag.id);
+      return normalizedNames.map((name) => tagsByName.get(name)!.id);
     }
 
     // 기존 태그만 반환
-    return existingTags.map((tag) => tag.id);
+    const tagsByName = new Map(repairedExistingTags.map((tag) => [tag.name, tag]));
+
+    return normalizedNames.map((name) => tagsByName.get(name)!.id);
   }
 
   /**
@@ -147,5 +151,162 @@ export class TagService {
       .filter((name) => name.length > 0);
 
     return [...new Set(normalized)];
+  }
+
+  private async repairLegacyTags(tags: Tag[]): Promise<Tag[]> {
+    const repairedTags: Tag[] = [];
+
+    for (const tag of tags) {
+      if (!needsLegacySlugRepair(tag.slug)) {
+        repairedTags.push(tag);
+        continue;
+      }
+
+      repairedTags.push(await this.repairTagSlug(tag.id, tag.name));
+    }
+
+    return repairedTags;
+  }
+
+  private async createTag(name: string): Promise<Tag> {
+    const [existing] = await this.db
+      .select()
+      .from(tagTable)
+      .where(eq(tagTable.name, name))
+      .limit(1);
+
+    if (existing) {
+      return needsLegacySlugRepair(existing.slug)
+        ? await this.repairTagSlug(existing.id, existing.name)
+        : existing;
+    }
+
+    try {
+      return await this.db.transaction(async (tx) => {
+        const newTag: NewTag = {
+          name,
+          slug: this.buildPendingSlug(),
+        };
+
+        const [result] = await tx.insert(tagTable).values(newTag);
+        const tagId = Number(result.insertId);
+        const resolvedSlug = await this.resolveTagSlug(tx, name, tagId);
+
+        if (resolvedSlug !== newTag.slug) {
+          await tx
+            .update(tagTable)
+            .set({ slug: resolvedSlug })
+            .where(eq(tagTable.id, tagId));
+        }
+
+        const [tag] = await tx
+          .select()
+          .from(tagTable)
+          .where(eq(tagTable.id, tagId))
+          .limit(1);
+
+        if (!tag) {
+          throw HttpError.internal("Failed to create tag.");
+        }
+
+        return tag;
+      });
+    } catch (error) {
+      if (this.isDuplicateEntry(error)) {
+        const [existingTag] = await this.db
+          .select()
+          .from(tagTable)
+          .where(eq(tagTable.name, name))
+          .limit(1);
+
+        if (existingTag) {
+          return needsLegacySlugRepair(existingTag.slug)
+            ? await this.repairTagSlug(existingTag.id, existingTag.name)
+            : existingTag;
+        }
+      }
+
+      throw error;
+    }
+  }
+
+  private async repairTagSlug(id: number, name: string): Promise<Tag> {
+    return await this.db.transaction(async (tx) => {
+      const resolvedSlug = await this.resolveTagSlug(tx, name, id, id);
+
+      await tx.update(tagTable).set({ slug: resolvedSlug }).where(eq(tagTable.id, id));
+
+      const [updated] = await tx
+        .select()
+        .from(tagTable)
+        .where(eq(tagTable.id, id))
+        .limit(1);
+
+      if (!updated) {
+        throw HttpError.internal("Failed to repair tag slug.");
+      }
+
+      return updated;
+    });
+  }
+
+  private buildPendingSlug(): string {
+    return `__pending__${Date.now()}-${Math.random().toString(36).slice(2, 10)}`;
+  }
+
+  private async resolveTagSlug(
+    tx: MySql2Database<typeof schema>,
+    name: string,
+    tagId: number,
+    excludeId?: number,
+  ): Promise<string> {
+    const preferredSlug = generateUnicodeSlug(name);
+
+    if (isBlankSlug(preferredSlug)) {
+      return await this.resolveFallbackSlug(tx, tagId, excludeId);
+    }
+
+    const existing = await tx
+      .select({ id: tagTable.id })
+      .from(tagTable)
+      .where(eq(tagTable.slug, preferredSlug))
+      .limit(1);
+
+    if (existing.length === 0 || existing[0]?.id === excludeId) {
+      return preferredSlug;
+    }
+
+    return await this.resolveFallbackSlug(tx, tagId, excludeId);
+  }
+
+  private async resolveFallbackSlug(
+    tx: MySql2Database<typeof schema>,
+    tagId: number,
+    excludeId?: number,
+  ): Promise<string> {
+    const baseSlug = String(tagId);
+
+    return await ensureUniqueSlug(baseSlug, async (checkSlug) => {
+      const existing = await tx
+        .select({ id: tagTable.id })
+        .from(tagTable)
+        .where(eq(tagTable.slug, checkSlug))
+        .limit(1);
+
+      if (existing.length === 0) {
+        return false;
+      }
+
+      return excludeId === undefined || existing[0]?.id !== excludeId;
+    });
+  }
+
+  private isDuplicateEntry(error: unknown): error is { code: string } {
+    return (
+      typeof error === "object" &&
+      error !== null &&
+      "code" in error &&
+      (error as { code?: string }).code === "ER_DUP_ENTRY"
+    );
   }
 }

--- a/src/shared/slug.ts
+++ b/src/shared/slug.ts
@@ -27,6 +27,14 @@ export function isBlankSlug(slug: string | null | undefined): boolean {
   return slug === undefined || slug === null || slug.trim().length === 0;
 }
 
+export function needsLegacySlugRepair(slug: string | null | undefined): boolean {
+  if (isBlankSlug(slug)) {
+    return true;
+  }
+
+  return /^-[0-9]+$/.test(slug.trim());
+}
+
 export function generateUnicodeSlug(text: string): string {
   return text
     .normalize("NFKC")

--- a/test/routes/categories.test.ts
+++ b/test/routes/categories.test.ts
@@ -142,6 +142,79 @@ describe("Category Routes", () => {
       expect(body.category.totalPostCount).toBe(0);
     });
 
+    it("한글 이름은 유니코드 slug로 생성 → 201", async () => {
+      await seedAdmin();
+      const cookie = await injectAuth(app);
+
+      const response = await app.inject({
+        method: "POST",
+        url: "/categories",
+        headers: { cookie },
+        payload: {
+          name: "일상",
+        },
+      });
+
+      expect(response.statusCode).toBe(201);
+      expect(response.json().category.slug).toBe("일상");
+    });
+
+    it("slug를 만들 수 없는 이름은 생성된 id fallback 사용 → 201", async () => {
+      await seedAdmin();
+      const cookie = await injectAuth(app);
+
+      const response = await app.inject({
+        method: "POST",
+        url: "/categories",
+        headers: { cookie },
+        payload: {
+          name: "😀😀😀",
+        },
+      });
+
+      expect(response.statusCode).toBe(201);
+
+      const body = response.json();
+      expect(body.category.slug).toBe(String(body.category.id));
+    });
+
+    it("수동 slug override를 정규화해 저장 → 201", async () => {
+      await seedAdmin();
+      const cookie = await injectAuth(app);
+
+      const response = await app.inject({
+        method: "POST",
+        url: "/categories",
+        headers: { cookie },
+        payload: {
+          name: "Manual Slug",
+          slug: "  커스텀 Slug!  ",
+        },
+      });
+
+      expect(response.statusCode).toBe(201);
+      expect(response.json().category.slug).toBe("커스텀-slug");
+    });
+
+    it("중복 수동 slug override는 400", async () => {
+      await seedAdmin();
+      const cookie = await injectAuth(app);
+      await seedCategory({ name: "Existing", slug: "중복-slug" });
+
+      const response = await app.inject({
+        method: "POST",
+        url: "/categories",
+        headers: { cookie },
+        payload: {
+          name: "Another",
+          slug: "중복 slug",
+        },
+      });
+
+      expect(response.statusCode).toBe(400);
+      expect(response.json().message).toContain("Slug already exists");
+    });
+
     it("비인증 → 403", async () => {
       const response = await app.inject({
         method: "POST",
@@ -187,6 +260,43 @@ describe("Category Routes", () => {
       const body = response.json();
       expect(body.category.name).toBe("Updated Name");
       expect(body.category.id).toBe(category.id);
+    });
+
+    it("legacy 빈 slug 카테고리를 수정하면 slug를 복구 → 200", async () => {
+      await seedAdmin();
+      const cookie = await injectAuth(app);
+      const category = await seedCategory({ name: "Broken", slug: "" });
+
+      const response = await app.inject({
+        method: "PATCH",
+        url: `/categories/${category.id}`,
+        headers: { cookie },
+        payload: {
+          name: "복구된 이름",
+        },
+      });
+
+      expect(response.statusCode).toBe(200);
+      expect(response.json().category.slug).toBe("복구된-이름");
+    });
+
+    it("PATCH 수동 slug override 충돌 시 400", async () => {
+      await seedAdmin();
+      const cookie = await injectAuth(app);
+      await seedCategory({ name: "Existing", slug: "manual-slug" });
+      const category = await seedCategory({ name: "Target", slug: "target-slug" });
+
+      const response = await app.inject({
+        method: "PATCH",
+        url: `/categories/${category.id}`,
+        headers: { cookie },
+        payload: {
+          slug: "manual slug",
+        },
+      });
+
+      expect(response.statusCode).toBe(400);
+      expect(response.json().message).toContain("Slug already exists");
     });
   });
 

--- a/test/routes/categories.test.ts
+++ b/test/routes/categories.test.ts
@@ -159,6 +159,34 @@ describe("Category Routes", () => {
       expect(response.json().category.slug).toBe("일상");
     });
 
+    it("자동 생성 slug 충돌 시 readable suffix를 유지 → 201", async () => {
+      await seedAdmin();
+      const cookie = await injectAuth(app);
+
+      const first = await app.inject({
+        method: "POST",
+        url: "/categories",
+        headers: { cookie },
+        payload: {
+          name: "일상",
+        },
+      });
+
+      const second = await app.inject({
+        method: "POST",
+        url: "/categories",
+        headers: { cookie },
+        payload: {
+          name: "일상",
+        },
+      });
+
+      expect(first.statusCode).toBe(201);
+      expect(second.statusCode).toBe(201);
+      expect(first.json().category.slug).toBe("일상");
+      expect(second.json().category.slug).toBe("일상-2");
+    });
+
     it("slug를 만들 수 없는 이름은 생성된 id fallback 사용 → 201", async () => {
       await seedAdmin();
       const cookie = await injectAuth(app);

--- a/test/routes/tags.test.ts
+++ b/test/routes/tags.test.ts
@@ -255,5 +255,42 @@ describe("Tag Routes", () => {
 
       expect(updatedTag?.slug).toBe("일상");
     });
+
+    it("같은 요청의 신규 태그 slug 충돌은 순차 생성으로 처리한다", async () => {
+      await seedAdmin();
+      const cookie = await injectAuth(app);
+      const category = await seedCategory();
+
+      const response = await app.inject({
+        method: "POST",
+        url: "/admin/posts",
+        headers: { cookie },
+        payload: {
+          title: "Colliding Tag Post",
+          contentMd: "# Colliding",
+          categoryId: category.id,
+          status: "published",
+          visibility: "public",
+          tags: ["C!", "C?"],
+        },
+      });
+
+      expect(response.statusCode).toBe(201);
+
+      const createdTags = await db
+        .select()
+        .from(tagTable)
+        .where(eq(tagTable.name, "c!"));
+      const collidingTags = await db
+        .select()
+        .from(tagTable)
+        .where(eq(tagTable.name, "c?"));
+
+      expect(createdTags).toHaveLength(1);
+      expect(collidingTags).toHaveLength(1);
+      expect(createdTags[0]?.slug).toBe("c");
+      expect(collidingTags[0]?.slug).not.toBe("c");
+      expect(collidingTags[0]?.slug).toBe(String(collidingTags[0]?.id));
+    });
   });
 });

--- a/test/routes/tags.test.ts
+++ b/test/routes/tags.test.ts
@@ -2,9 +2,9 @@ import { FastifyInstance } from "fastify";
 import { describe, it, expect, beforeAll, afterAll, beforeEach } from "vitest";
 import { eq } from "drizzle-orm";
 import { createTestApp, cleanup, injectAuth } from "@test/helpers/app";
-import { seedAdmin, seedCategory, truncateAll } from "@test/helpers/seed";
+import { seedAdmin, seedCategory, seedTag, truncateAll } from "@test/helpers/seed";
 import { db } from "@src/db/client";
-import { postTable } from "@src/db/schema";
+import { postTable, tagTable } from "@src/db/schema";
 
 describe("Tag Routes", () => {
   let app: FastifyInstance;
@@ -161,6 +161,99 @@ describe("Tag Routes", () => {
       expect(body.tags).toEqual([
         { id: expect.any(Number), name: "react", slug: "react", postCount: 1 },
       ]);
+    });
+
+    it("한글 태그는 유니코드 slug로 생성한다", async () => {
+      await seedAdmin();
+      const cookie = await injectAuth(app);
+      const category = await seedCategory();
+
+      await app.inject({
+        method: "POST",
+        url: "/admin/posts",
+        headers: { cookie },
+        payload: {
+          title: "Korean Tag Post",
+          contentMd: "# Korean",
+          categoryId: category.id,
+          status: "published",
+          visibility: "public",
+          tags: ["한글 태그"],
+        },
+      });
+
+      const response = await app.inject({
+        method: "GET",
+        url: "/tags",
+      });
+
+      expect(response.statusCode).toBe(200);
+      expect(response.json().tags).toEqual([
+        {
+          id: expect.any(Number),
+          name: "한글 태그",
+          slug: "한글-태그",
+          postCount: 1,
+        },
+      ]);
+    });
+
+    it("slug를 만들 수 없는 태그는 id fallback slug를 사용한다", async () => {
+      await seedAdmin();
+      const cookie = await injectAuth(app);
+      const category = await seedCategory();
+
+      await app.inject({
+        method: "POST",
+        url: "/admin/posts",
+        headers: { cookie },
+        payload: {
+          title: "Emoji Tag Post",
+          contentMd: "# Emoji",
+          categoryId: category.id,
+          status: "published",
+          visibility: "public",
+          tags: ["😀"],
+        },
+      });
+
+      const response = await app.inject({
+        method: "GET",
+        url: "/tags",
+      });
+
+      expect(response.statusCode).toBe(200);
+
+      const [tag] = response.json().tags;
+      expect(tag.slug).toBe(String(tag.id));
+    });
+
+    it("기존 legacy 빈 slug 태그를 재사용하면 slug를 복구한다", async () => {
+      await seedAdmin();
+      const cookie = await injectAuth(app);
+      const category = await seedCategory();
+      const brokenTag = await seedTag({ name: "일상", slug: "" });
+
+      await app.inject({
+        method: "POST",
+        url: "/admin/posts",
+        headers: { cookie },
+        payload: {
+          title: "Repair Tag Post",
+          contentMd: "# Repair",
+          categoryId: category.id,
+          status: "published",
+          visibility: "public",
+          tags: ["일상"],
+        },
+      });
+
+      const [updatedTag] = await db
+        .select()
+        .from(tagTable)
+        .where(eq(tagTable.id, brokenTag.id));
+
+      expect(updatedTag?.slug).toBe("일상");
     });
   });
 });

--- a/test/shared/slug.test.ts
+++ b/test/shared/slug.test.ts
@@ -1,0 +1,17 @@
+import { describe, expect, it } from "vitest";
+import {
+  generateUnicodeSlug,
+  needsLegacySlugRepair,
+} from "@src/shared/slug";
+
+describe("shared/slug", () => {
+  it("한글과 영문 혼합 텍스트를 유니코드 slug로 정규화한다", () => {
+    expect(generateUnicodeSlug(" 안녕 Hello World! ")).toBe("안녕-hello-world");
+  });
+
+  it("legacy 빈 slug 또는 -숫자 slug 를 복구 대상으로 판단한다", () => {
+    expect(needsLegacySlugRepair("")).toBe(true);
+    expect(needsLegacySlugRepair("-2")).toBe(true);
+    expect(needsLegacySlugRepair("정상-slug")).toBe(false);
+  });
+});


### PR DESCRIPTION
## Summary

Closes #111

Repair category/tag slug generation so Unicode names no longer collapse to blank slugs, support manual category slug overrides, and provide a dry-run repair script for legacy broken taxonomy rows.

## Changes

| File | Change |
|------|--------|
| `src/shared/slug.ts` | added shared legacy-slug detection helper used by post/category/tag flows |
| `src/routes/categories/category.*` | switched category create/update to Unicode slug resolution with id fallback, optional manual slug override, and legacy-slug repair on update |
| `src/routes/tags/tag.service.ts` | switched tag creation/repair to Unicode slug resolution with id fallback and legacy repair on reuse |
| `scripts/repair-taxonomy-slugs.ts` | added dry-run/apply repair CLI for legacy category/tag slugs |
| `test/routes/categories.test.ts`, `test/routes/tags.test.ts`, `test/shared/slug.test.ts` | added coverage for Unicode slugs, numeric fallback, manual override conflicts, and legacy repair |
