### PR TITLE
fix: handle null trash post categories (#113)

### DIFF
--- a/src/routes/posts/post.schema.ts
+++ b/src/routes/posts/post.schema.ts
@@ -300,7 +300,7 @@ export const PostDetailCategorySchema = PostCategorySchema.extend({
 
 const PostBaseFields = {
   id: z.number().describe("게시글 ID"),
-  categoryId: z.number().describe("카테고리 ID"),
+  categoryId: z.number().nullable().describe("카테고리 ID"),
   title: z.string().describe("게시글 제목"),
   slug: z.string().describe("게시글 슬러그"),
   summary: z.string().nullable().describe("게시글 요약"),
@@ -328,12 +328,12 @@ const PostBaseFields = {
 export const PostDetailSchema = z.object({
   ...PostBaseFields,
   contentMd: z.string().describe("마크다운 본문"),
-  category: PostDetailCategorySchema,
+  category: PostDetailCategorySchema.nullable(),
 });
 
 export const PostListItemSchema = z.object({
   ...PostBaseFields,
-  category: PostCategorySchema,
+  category: PostCategorySchema.nullable(),
 });
 
 export const PostNavigationSchema = z.object({

--- a/src/routes/posts/post.service.ts
+++ b/src/routes/posts/post.service.ts
@@ -187,7 +187,7 @@ interface PostAggregates {
  */
 export type PostListItem = Omit<Post, "contentMd"> &
   PostAggregates & {
-    category: PostListCategory;
+    category: PostListCategory | null;
     tags: PostTag[];
   };
 
@@ -196,7 +196,7 @@ export type PostListItem = Omit<Post, "contentMd"> &
  */
 export type PostDetail = Post &
   PostAggregates & {
-    category: PostDetailCategory;
+    category: PostDetailCategory | null;
     tags: PostTag[];
   };
 
@@ -778,6 +778,12 @@ export class PostService {
         throw HttpError.notFound("게시글을 찾을 수 없습니다");
       }
 
+      if (currentPost.categoryId === null) {
+        throw HttpError.badRequest(
+          "카테고리가 없는 게시글은 복원할 수 없습니다. 먼저 카테고리를 다시 지정하세요.",
+        );
+      }
+
       if (currentPost.isPinned && currentPost.deletedAt !== null) {
         const pinnedCount = await this.countPinnedPosts(this.db);
 
@@ -859,6 +865,7 @@ export class PostService {
         const found = await tx
           .select({
             id: postTable.id,
+            categoryId: postTable.categoryId,
             isPinned: postTable.isPinned,
             deletedAt: postTable.deletedAt,
           })
@@ -902,6 +909,16 @@ export class PostService {
             .set({ deletedAt: new Date() })
             .where(inArray(postTable.id, uniqueIds));
         } else if (action === "restore") {
+          const uncategorizedPostsToRestore = found.filter(
+            (post) => post.deletedAt !== null && post.categoryId === null,
+          );
+
+          if (uncategorizedPostsToRestore.length > 0) {
+            throw HttpError.badRequest(
+              "카테고리가 없는 게시글은 복원할 수 없습니다. 먼저 카테고리를 다시 지정하세요.",
+            );
+          }
+
           const pinnedPostsToRestore = found.filter(
             (post) => post.isPinned && post.deletedAt !== null,
           ).length;
@@ -995,18 +1012,26 @@ export class PostService {
     if (posts.length === 0) return [];
 
     const postIds = posts.map((p) => p.id);
-    const categoryIds = [...new Set(posts.map((p) => p.categoryId))];
+    const categoryIds = [
+      ...new Set(
+        posts
+          .map((p) => p.categoryId)
+          .filter((categoryId): categoryId is number => categoryId !== null),
+      ),
+    ];
 
     const [categories, allPostTags, statsRows, commentRows] = await Promise.all(
       [
-        this.db
-          .select({
-            id: categoryTable.id,
-            name: categoryTable.name,
-            slug: categoryTable.slug,
-          })
-          .from(categoryTable)
-          .where(inArray(categoryTable.id, categoryIds)),
+        categoryIds.length === 0
+          ? Promise.resolve([])
+          : this.db
+              .select({
+                id: categoryTable.id,
+                name: categoryTable.name,
+                slug: categoryTable.slug,
+              })
+              .from(categoryTable)
+              .where(inArray(categoryTable.id, categoryIds)),
         this.db
           .select({
             postId: postTagTable.postId,
@@ -1049,8 +1074,9 @@ export class PostService {
     );
 
     return posts.map(({ contentMd: _c, ...post }) => {
-      const category = catMap.get(post.categoryId);
-      if (!category)
+      const category =
+        post.categoryId === null ? null : catMap.get(post.categoryId);
+      if (post.categoryId !== null && !category)
         throw HttpError.notFound(
           `Category ${post.categoryId} not found for post ${post.id}`,
         );
@@ -1120,6 +1146,38 @@ export class PostService {
    * 게시글 상세 정보 조회 (category ancestors + 집계 포함)
    */
   private async enrichPostWithDetails(post: Post): Promise<PostDetail> {
+    if (post.categoryId === null) {
+      const [postTags, totalPageviews, commentCount] = await Promise.all([
+        this.db
+          .select({ id: tagTable.id, name: tagTable.name, slug: tagTable.slug })
+          .from(postTagTable)
+          .innerJoin(tagTable, eq(postTagTable.tagId, tagTable.id))
+          .where(eq(postTagTable.postId, post.id)),
+        this.db
+          .select({
+            total: sql<number>`COALESCE(SUM(${statsDailyTable.pageviews}), 0)`,
+          })
+          .from(statsDailyTable)
+          .where(eq(statsDailyTable.postId, post.id))
+          .then((rows) => Number(rows[0]?.total ?? 0)),
+        this.db
+          .select({ count: sql<number>`COUNT(*)` })
+          .from(commentTable)
+          .where(
+            this.buildVisibleCommentWhere(eq(commentTable.postId, post.id)),
+          )
+          .then((rows) => Number(rows[0]?.count ?? 0)),
+      ]);
+
+      return {
+        ...post,
+        category: null,
+        tags: postTags,
+        totalPageviews,
+        commentCount,
+      };
+    }
+
     const [category, postTags, totalPageviews, commentCount, ancestors] =
       await Promise.all([
         this.db
@@ -1225,6 +1283,38 @@ export class PostService {
 
     if (!post) {
       throw HttpError.notFound("게시글을 찾을 수 없습니다");
+    }
+
+    if (post.categoryId === null) {
+      const [postTags, totalPageviews, commentCount] = await Promise.all([
+        tx
+          .select({ id: tagTable.id, name: tagTable.name, slug: tagTable.slug })
+          .from(postTagTable)
+          .innerJoin(tagTable, eq(postTagTable.tagId, tagTable.id))
+          .where(eq(postTagTable.postId, post.id)),
+        tx
+          .select({
+            total: sql<number>`COALESCE(SUM(${statsDailyTable.pageviews}), 0)`,
+          })
+          .from(statsDailyTable)
+          .where(eq(statsDailyTable.postId, post.id))
+          .then((rows) => Number(rows[0]?.total ?? 0)),
+        tx
+          .select({ count: sql<number>`COUNT(*)` })
+          .from(commentTable)
+          .where(
+            this.buildVisibleCommentWhere(eq(commentTable.postId, post.id)),
+          )
+          .then((rows) => Number(rows[0]?.count ?? 0)),
+      ]);
+
+      return {
+        ...post,
+        category: null,
+        tags: postTags,
+        totalPageviews,
+        commentCount,
+      };
     }
 
     const [category, postTags, totalPageviews, commentCount, ancestors] =

--- a/test/routes/posts.test.ts
+++ b/test/routes/posts.test.ts
@@ -10,7 +10,7 @@ import {
   truncateAll,
 } from "@test/helpers/seed";
 import { db } from "@src/db/client";
-import { statsDailyTable, tagTable } from "@src/db/schema";
+import { postTable, statsDailyTable, tagTable } from "@src/db/schema";
 
 describe("Post Routes", () => {
   let app: FastifyInstance;
@@ -916,6 +916,30 @@ describe("Post Routes", () => {
       expect(body.post.category.ancestors[0].name).toBe("Parent");
     });
 
+    it("category 삭제(trash)된 글 상세도 200으로 반환", async () => {
+      await seedAdmin();
+      const cookie = await injectAuth(app);
+      const category = await seedCategory();
+      const post = await seedPost(category.id);
+
+      const deleteCategoryResponse = await app.inject({
+        method: "DELETE",
+        url: `/categories/${category.id}?action=trash`,
+        headers: { cookie },
+      });
+      expect(deleteCategoryResponse.statusCode).toBe(204);
+
+      const response = await app.inject({
+        method: "GET",
+        url: `/admin/posts/${post.id}`,
+        headers: { cookie },
+      });
+
+      expect(response.statusCode).toBe(200);
+      expect(response.json().post.categoryId).toBeNull();
+      expect(response.json().post.category).toBeNull();
+    });
+
     it("존재하지 않는 ID → 404", async () => {
       await seedAdmin();
       const cookie = await injectAuth(app);
@@ -1080,6 +1104,34 @@ describe("Post Routes", () => {
 
       expect(withoutDeleted.json().data).toHaveLength(0);
       expect(withDeleted.json().data).toHaveLength(1);
+    });
+
+    it("includeDeleted=true + category 삭제(trash)된 글도 200으로 반환", async () => {
+      await seedAdmin();
+      const cookie = await injectAuth(app);
+      const category = await seedCategory();
+      const post = await seedPost(category.id);
+
+      const deleteCategoryResponse = await app.inject({
+        method: "DELETE",
+        url: `/categories/${category.id}?action=trash`,
+        headers: { cookie },
+      });
+      expect(deleteCategoryResponse.statusCode).toBe(204);
+
+      const response = await app.inject({
+        method: "GET",
+        url: "/admin/posts?includeDeleted=true",
+        headers: { cookie },
+      });
+
+      expect(response.statusCode).toBe(200);
+      const deletedPost = response
+        .json()
+        .data.find((item: { id: number }) => item.id === post.id);
+      expect(deletedPost).toBeDefined();
+      expect(deletedPost.categoryId).toBeNull();
+      expect(deletedPost.category).toBeNull();
     });
 
     it("includeDeleted=false 쿼리스트링 → 삭제된 글 제외 (회귀 방지)", async () => {
@@ -1851,6 +1903,31 @@ describe("Post Routes", () => {
       expect(response.statusCode).toBe(409);
       expect(response.json().message).toContain("Pinned post limit exceeded");
     });
+
+    it("카테고리가 null인 글 복원 시 400 반환", async () => {
+      await seedAdmin();
+      const cookie = await injectAuth(app);
+      const category = await seedCategory();
+      const post = await seedPost(category.id);
+
+      const deleteCategoryResponse = await app.inject({
+        method: "DELETE",
+        url: `/categories/${category.id}?action=trash`,
+        headers: { cookie },
+      });
+      expect(deleteCategoryResponse.statusCode).toBe(204);
+
+      const response = await app.inject({
+        method: "PUT",
+        url: `/admin/posts/${post.id}/restore`,
+        headers: { cookie },
+      });
+
+      expect(response.statusCode).toBe(400);
+      expect(response.json().message).toContain(
+        "카테고리가 없는 게시글은 복원할 수 없습니다",
+      );
+    });
   });
 
   // ===== PATCH /admin/posts/bulk =====
@@ -2002,6 +2079,38 @@ describe("Post Routes", () => {
         headers: { cookie },
       });
       expect(getRes.json().post.deletedAt).toBeNull();
+    });
+
+    it("action=restore: categoryId=null 글 포함 시 400", async () => {
+      await seedAdmin();
+      const cookie = await injectAuth(app);
+      const category = await seedCategory();
+      const post = await seedPost(category.id);
+
+      const deleteCategoryResponse = await app.inject({
+        method: "DELETE",
+        url: `/categories/${category.id}?action=trash`,
+        headers: { cookie },
+      });
+      expect(deleteCategoryResponse.statusCode).toBe(204);
+
+      const response = await app.inject({
+        method: "PATCH",
+        url: "/admin/posts/bulk",
+        headers: { cookie },
+        payload: { ids: [post.id], action: "restore" },
+      });
+
+      expect(response.statusCode).toBe(400);
+      expect(response.json().message).toContain(
+        "카테고리가 없는 게시글은 복원할 수 없습니다",
+      );
+
+      const [row] = await db
+        .select()
+        .from(postTable)
+        .where(eq(postTable.id, post.id));
+      expect(row?.deletedAt).not.toBeNull();
     });
 
     it("action=restore: pinned 복원으로 6개가 되면 409", async () => {


### PR DESCRIPTION
## Summary

Closes #113

Handle deleted posts whose category was removed so admin trash views no longer 500, and reject restore until a category is reassigned.

## Changes

| File | Change |
|------|--------|
| `src/routes/posts/post.service.ts` | Allow null category enrichment for trash/admin reads, guard single and bulk restore when category is missing, and skip empty category lookups. |
| `src/routes/posts/post.schema.ts` | Mark `categoryId` and `category` response fields nullable in post responses. |
| `test/routes/posts.test.ts` | Add regressions for trash list/detail reads and single and bulk restore failures. |
