### PR TITLE
chore: bump server version to 1.1.4

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "pyosh-blog-be",
-  "version": "1.1.2",
+  "version": "1.1.4",
   "repository": "https://github.com/pyo-sh/pyosh-blog-be.git",
   "license": "MIT",
   "author": "pyo-sh <pygosky@gmail.com>",


### PR DESCRIPTION
## Summary

`v1.1.4` 릴리스를 위한 버전 bump.

- `package.json`: `1.1.2` → `1.1.4` (직전 두 패치 릴리스에서 누락된 bump 포함)

## Release contents

- Fix: handle null trash post categories (#113, #114)