### PR TITLE
fix: clean up server lint for v1.1.5 release

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "pyosh-blog-be",
-  "version": "1.1.4",
+  "version": "1.1.5",
   "repository": "https://github.com/pyo-sh/pyosh-blog-be.git",
   "license": "MIT",
   "author": "pyo-sh <pygosky@gmail.com>",

--- a/src/routes/categories/category.service.ts
+++ b/src/routes/categories/category.service.ts
@@ -118,12 +118,7 @@ export class CategoryService {
 
       const [result] = await tx.insert(categoryTable).values(newCategory);
       const categoryId = Number(result.insertId);
-      await this.finalizeCategorySlug(
-        tx,
-        categoryId,
-        data.name,
-        data.slug,
-      );
+      await this.finalizeCategorySlug(tx, categoryId, data.name, data.slug);
 
       const [category] = await tx
         .select()
@@ -277,7 +272,10 @@ export class CategoryService {
         );
       }
 
-      await tx.update(categoryTable).set(updates).where(eq(categoryTable.id, id));
+      await tx
+        .update(categoryTable)
+        .set(updates)
+        .where(eq(categoryTable.id, id));
 
       const [updated] = await tx
         .select()
@@ -303,133 +301,6 @@ export class CategoryService {
         totalPostCount: Number(counts?.totalPostCount ?? 0),
       };
     });
-  }
-
-  private buildPendingSlug(): string {
-    return `__pending__${Date.now()}-${Math.random().toString(36).slice(2, 10)}`;
-  }
-
-  private async resolveCategorySlug(
-    tx: MySql2Database<typeof schema>,
-    name: string,
-    categoryId: number,
-    requestedSlug?: string,
-    excludeId?: number,
-  ): Promise<string> {
-    const preferredSlug =
-      requestedSlug !== undefined
-        ? this.normalizeRequestedSlug(requestedSlug)
-        : generateUnicodeSlug(name);
-
-    if (requestedSlug === undefined && isBlankSlug(preferredSlug)) {
-      return await this.resolveFallbackSlug(tx, categoryId, excludeId);
-    }
-
-    const existing = await tx
-      .select({ id: categoryTable.id })
-      .from(categoryTable)
-      .where(eq(categoryTable.slug, preferredSlug))
-      .limit(1);
-
-    if (existing.length === 0 || existing[0]?.id === excludeId) {
-      return preferredSlug;
-    }
-
-    if (requestedSlug !== undefined) {
-      throw HttpError.badRequest("Slug already exists.");
-    }
-
-    return await ensureUniqueSlug(preferredSlug, async (checkSlug) => {
-      const duplicate = await tx
-        .select({ id: categoryTable.id })
-        .from(categoryTable)
-        .where(eq(categoryTable.slug, checkSlug))
-        .limit(1);
-
-      if (duplicate.length === 0) {
-        return false;
-      }
-
-      return excludeId === undefined || duplicate[0]?.id !== excludeId;
-    });
-  }
-
-  private normalizeRequestedSlug(slug: string): string {
-    const normalizedSlug = generateUnicodeSlug(slug);
-
-    if (isBlankSlug(normalizedSlug)) {
-      throw HttpError.badRequest("Slug cannot be blank after normalization.");
-    }
-
-    return normalizedSlug;
-  }
-
-  private async resolveFallbackSlug(
-    tx: MySql2Database<typeof schema>,
-    categoryId: number,
-    excludeId?: number,
-  ): Promise<string> {
-    const baseSlug = String(categoryId);
-
-    return await ensureUniqueSlug(baseSlug, async (checkSlug) => {
-      const existing = await tx
-        .select({ id: categoryTable.id })
-        .from(categoryTable)
-        .where(eq(categoryTable.slug, checkSlug))
-        .limit(1);
-
-      if (existing.length === 0) {
-        return false;
-      }
-
-      return excludeId === undefined || existing[0]?.id !== excludeId;
-    });
-  }
-
-  private async finalizeCategorySlug(
-    tx: MySql2Database<typeof schema>,
-    categoryId: number,
-    name: string,
-    requestedSlug?: string,
-    excludeId?: number,
-  ): Promise<string> {
-    for (let attempt = 0; attempt < 5; attempt++) {
-      const resolvedSlug = await this.resolveCategorySlug(
-        tx,
-        name,
-        categoryId,
-        requestedSlug,
-        excludeId,
-      );
-
-      try {
-        await tx
-          .update(categoryTable)
-          .set({ slug: resolvedSlug })
-          .where(eq(categoryTable.id, categoryId));
-
-        return resolvedSlug;
-      } catch (error) {
-        if (!this.isDuplicateEntry(error)) {
-          throw error;
-        }
-
-        if (requestedSlug !== undefined) {
-          throw HttpError.badRequest("Slug already exists.");
-        }
-      }
-    }
-
-    throw HttpError.internal("Failed to finalize category slug.");
-  }
-
-  private isDuplicateEntry(error: unknown): error is { code: string } {
-    return (
-      typeof error === "object" &&
-      error !== null &&
-      "code" in error &&
-      (error as { code?: string }).code === "ER_DUP_ENTRY"
-    );
   }
 
   /**
@@ -619,6 +490,133 @@ export class CategoryService {
       // 카테고리 삭제
       await tx.delete(categoryTable).where(eq(categoryTable.id, id));
     });
+  }
+
+  private buildPendingSlug(): string {
+    return `__pending__${Date.now()}-${Math.random().toString(36).slice(2, 10)}`;
+  }
+
+  private async resolveCategorySlug(
+    tx: MySql2Database<typeof schema>,
+    name: string,
+    categoryId: number,
+    requestedSlug?: string,
+    excludeId?: number,
+  ): Promise<string> {
+    const preferredSlug =
+      requestedSlug !== undefined
+        ? this.normalizeRequestedSlug(requestedSlug)
+        : generateUnicodeSlug(name);
+
+    if (requestedSlug === undefined && isBlankSlug(preferredSlug)) {
+      return await this.resolveFallbackSlug(tx, categoryId, excludeId);
+    }
+
+    const existing = await tx
+      .select({ id: categoryTable.id })
+      .from(categoryTable)
+      .where(eq(categoryTable.slug, preferredSlug))
+      .limit(1);
+
+    if (existing.length === 0 || existing[0]?.id === excludeId) {
+      return preferredSlug;
+    }
+
+    if (requestedSlug !== undefined) {
+      throw HttpError.badRequest("Slug already exists.");
+    }
+
+    return await ensureUniqueSlug(preferredSlug, async (checkSlug) => {
+      const duplicate = await tx
+        .select({ id: categoryTable.id })
+        .from(categoryTable)
+        .where(eq(categoryTable.slug, checkSlug))
+        .limit(1);
+
+      if (duplicate.length === 0) {
+        return false;
+      }
+
+      return excludeId === undefined || duplicate[0]?.id !== excludeId;
+    });
+  }
+
+  private normalizeRequestedSlug(slug: string): string {
+    const normalizedSlug = generateUnicodeSlug(slug);
+
+    if (isBlankSlug(normalizedSlug)) {
+      throw HttpError.badRequest("Slug cannot be blank after normalization.");
+    }
+
+    return normalizedSlug;
+  }
+
+  private async resolveFallbackSlug(
+    tx: MySql2Database<typeof schema>,
+    categoryId: number,
+    excludeId?: number,
+  ): Promise<string> {
+    const baseSlug = String(categoryId);
+
+    return await ensureUniqueSlug(baseSlug, async (checkSlug) => {
+      const existing = await tx
+        .select({ id: categoryTable.id })
+        .from(categoryTable)
+        .where(eq(categoryTable.slug, checkSlug))
+        .limit(1);
+
+      if (existing.length === 0) {
+        return false;
+      }
+
+      return excludeId === undefined || existing[0]?.id !== excludeId;
+    });
+  }
+
+  private async finalizeCategorySlug(
+    tx: MySql2Database<typeof schema>,
+    categoryId: number,
+    name: string,
+    requestedSlug?: string,
+    excludeId?: number,
+  ): Promise<string> {
+    for (let attempt = 0; attempt < 5; attempt++) {
+      const resolvedSlug = await this.resolveCategorySlug(
+        tx,
+        name,
+        categoryId,
+        requestedSlug,
+        excludeId,
+      );
+
+      try {
+        await tx
+          .update(categoryTable)
+          .set({ slug: resolvedSlug })
+          .where(eq(categoryTable.id, categoryId));
+
+        return resolvedSlug;
+      } catch (error) {
+        if (!this.isDuplicateEntry(error)) {
+          throw error;
+        }
+
+        if (requestedSlug !== undefined) {
+          throw HttpError.badRequest("Slug already exists.");
+        }
+      }
+    }
+
+    throw HttpError.internal("Failed to finalize category slug.");
+  }
+
+  private isDuplicateEntry(error: unknown): error is { code: string } {
+    return (
+      typeof error === "object" &&
+      error !== null &&
+      "code" in error &&
+      (error as { code?: string }).code === "ER_DUP_ENTRY"
+    );
   }
 
   /**

--- a/src/routes/tags/tag.service.ts
+++ b/src/routes/tags/tag.service.ts
@@ -12,10 +12,10 @@ import { MySql2Database } from "drizzle-orm/mysql2";
 import { z } from "zod";
 import { TagWithPostCountSchema } from "./tag.schema";
 import * as schema from "@src/db/schema/index";
-import { HttpError } from "@src/errors/http-error";
 import { postTagTable } from "@src/db/schema/post-tags";
 import { postTable } from "@src/db/schema/posts";
 import { Tag, tagTable, NewTag } from "@src/db/schema/tags";
+import { HttpError } from "@src/errors/http-error";
 import {
   ensureUniqueSlug,
   generateUnicodeSlug,
@@ -75,7 +75,9 @@ export class TagService {
     }
 
     // 기존 태그만 반환
-    const tagsByName = new Map(repairedExistingTags.map((tag) => [tag.name, tag]));
+    const tagsByName = new Map(
+      repairedExistingTags.map((tag) => [tag.name, tag]),
+    );
 
     return normalizedNames.map((name) => tagsByName.get(name)!.id);
   }
@@ -300,10 +302,18 @@ export class TagService {
     excludeId?: number,
   ): Promise<string> {
     for (let attempt = 0; attempt < 5; attempt++) {
-      const resolvedSlug = await this.resolveTagSlug(tx, name, tagId, excludeId);
+      const resolvedSlug = await this.resolveTagSlug(
+        tx,
+        name,
+        tagId,
+        excludeId,
+      );
 
       try {
-        await tx.update(tagTable).set({ slug: resolvedSlug }).where(eq(tagTable.id, tagId));
+        await tx
+          .update(tagTable)
+          .set({ slug: resolvedSlug })
+          .where(eq(tagTable.id, tagId));
 
         return resolvedSlug;
       } catch (error) {

--- a/src/shared/slug.ts
+++ b/src/shared/slug.ts
@@ -27,7 +27,9 @@ export function isBlankSlug(slug: string | null | undefined): boolean {
   return slug === undefined || slug === null || slug.trim().length === 0;
 }
 
-export function needsLegacySlugRepair(slug: string | null | undefined): boolean {
+export function needsLegacySlugRepair(
+  slug: string | null | undefined,
+): boolean {
   if (isBlankSlug(slug)) {
     return true;
   }


### PR DESCRIPTION
## Summary

Follow-up patch after `v1.1.4` to clear server lint failures and cut a clean release candidate.

- fix Prettier formatting in category/tag services and shared slug helper
- reorder `CategoryService` members to satisfy `@typescript-eslint/member-ordering`
- bump server version from `1.1.4` to `1.1.5`

## Verification

- `pnpm lint`
- `pnpm test`
