### PR TITLE
fix: allow guestbook create without guest email (#117)

### DIFF
--- a/src/routes/guestbook/guestbook.route.ts
+++ b/src/routes/guestbook/guestbook.route.ts
@@ -87,7 +87,7 @@ export function createGuestbookRoute(
           tags: ["guestbook"],
           summary: "방명록 작성",
           description:
-            "OAuth 로그인 사용자 또는 게스트가 방명록을 작성합니다. 게스트는 이름, 이메일, 비밀번호를 함께 전달해야 합니다.\n\n" +
+            "OAuth 로그인 사용자 또는 게스트가 방명록을 작성합니다. 게스트는 이름과 비밀번호를 전달해야 하며, 이메일은 선택입니다.\n\n" +
             "**CSRF 토큰 필요**: `GET /auth/csrf-token`으로 토큰을 발급받아 " +
             "`x-csrf-token` 헤더에 포함해야 합니다.\n\n" +
             "**Rate limit**: 10회/분",

--- a/src/routes/guestbook/guestbook.schema.ts
+++ b/src/routes/guestbook/guestbook.schema.ts
@@ -68,6 +68,7 @@ export const CreateGuestbookGuestBodySchema =
       .string()
       .email("유효한 이메일 주소를 입력하세요")
       .max(100, "이메일은 100자를 초과할 수 없습니다")
+      .optional()
       .describe("게스트 이메일"),
     guestPassword: z
       .string()

--- a/test/routes/guestbook.test.ts
+++ b/test/routes/guestbook.test.ts
@@ -71,6 +71,27 @@ describe("Guestbook Routes", () => {
       expect(body.data.author.name).toBe("방문자");
     });
 
+    it("게스트 이메일 없이 방명록 작성 → 201", async () => {
+      const csrfHeaders = await getCsrfHeaders();
+      const response = await app.inject({
+        method: "POST",
+        url: "/guestbook",
+        headers: csrfHeaders,
+        payload: {
+          body: "이메일 없이 작성한 방명록입니다.",
+          guestName: "익명 방문자",
+          guestPassword: "pass1234",
+        },
+      });
+
+      expect(response.statusCode).toBe(201);
+
+      const body = response.json();
+      expect(body.data.author.type).toBe("guest");
+      expect(body.data.author.name).toBe("익명 방문자");
+      expect(body.data.author.email).toBeUndefined();
+    });
+
     it("OAuth 사용자 방명록 작성 → 201", async () => {
       const user = await seedOAuthUser({ displayName: "OAuth Visitor" });
       const cookie = await injectOAuthUser(user.id);


### PR DESCRIPTION
## Summary

Closes #117

Align the guestbook create API with the actual product behavior by allowing guest submissions without an email address and covering that case with an integration test.

## Changes

| File | Change |
|------|--------|
| `src/routes/guestbook/guestbook.schema.ts` | Make `guestEmail` optional for guest guestbook creation payloads |
| `test/routes/guestbook.test.ts` | Add integration coverage for guestbook creation without `guestEmail` |

## Screenshots

N/A
