### PR TITLE
feat: add category bulk delete API (#119)

### DIFF
--- a/src/routes/categories/category.route.ts
+++ b/src/routes/categories/category.route.ts
@@ -5,6 +5,7 @@ import {
   CategoryIdParamSchema,
   CategoryListQuerySchema,
   CategoryDeleteQuerySchema,
+  CategoryBulkDeleteBodySchema,
   CategoryCreateBodySchema,
   CategoryUpdateBodySchema,
   CategoryTreeUpdateBodySchema,
@@ -195,6 +196,40 @@ export function createCategoryRoute(
             updatedAt: category.updatedAt.toISOString(),
           },
         });
+      },
+    );
+
+    // DELETE /categories/bulk - 카테고리 벌크 삭제 (Admin)
+    // 반드시 /:id 앞에 등록해야 정적 경로 우선 매칭 보장
+    typedFastify.delete(
+      "/bulk",
+      {
+        onRequest: fastify.csrfProtection,
+        preHandler: requireAdmin(adminService),
+        schema: {
+          tags: ["categories"],
+          summary: "Bulk delete categories",
+          description:
+            "여러 카테고리를 단일 트랜잭션으로 삭제합니다. action=move면 미삭제 게시글을 지정 카테고리로 이동하고, action=trash면 미삭제 게시글을 휴지통으로 이동합니다. 하위 카테고리가 있으면 삭제할 수 없습니다. Admin 권한이 필요합니다.\n\n" +
+            "**CSRF 토큰 필요**: `GET /auth/csrf-token`으로 토큰을 발급받아 " +
+            "`x-csrf-token` 헤더에 포함해야 합니다.",
+          security: [{ cookieAuth: [] }],
+          body: CategoryBulkDeleteBodySchema,
+          response: {
+            204: z.void(),
+            400: ErrorResponseSchema,
+            403: ErrorResponseSchema,
+            404: ErrorResponseSchema,
+            409: ErrorResponseSchema,
+          },
+        },
+      },
+      async (request, reply) => {
+        const { ids, action, moveTo } = request.body;
+
+        await categoryService.deleteCategories({ ids, action, moveTo });
+
+        return reply.status(204).send();
       },
     );
 

--- a/src/routes/categories/category.schema.ts
+++ b/src/routes/categories/category.schema.ts
@@ -108,6 +108,31 @@ export const CategoryTreeUpdateBodySchema = z.object({
     .describe("변경할 카테고리 목록 (최대 200개)"),
 });
 
+export const CategoryBulkDeleteBodySchema = z
+  .object({
+    ids: z
+      .array(z.number().int().positive())
+      .min(1, "At least one category ID is required")
+      .max(100, "Too many categories in a single request")
+      .refine((ids) => new Set(ids).size === ids.length, {
+        message: "Duplicate category IDs are not allowed",
+      })
+      .describe("삭제할 카테고리 ID 목록 (최대 100개)"),
+    action: z
+      .enum(["move", "trash"])
+      .describe("삭제 방식 (move: 게시글 이동, trash: 게시글 휴지통)"),
+    moveTo: z
+      .number()
+      .int()
+      .positive()
+      .optional()
+      .describe("게시글을 이동할 카테고리 ID (action=move 시 필수)"),
+  })
+  .refine((data) => data.action !== "move" || data.moveTo != null, {
+    message: "moveTo is required when action is move",
+    path: ["moveTo"],
+  });
+
 /**
  * Response Schemas
  */
@@ -178,3 +203,6 @@ export type CategoryTreeUpdateBody = z.infer<
   typeof CategoryTreeUpdateBodySchema
 >;
 export type CategoryDeleteQuery = z.infer<typeof CategoryDeleteQuerySchema>;
+export type CategoryBulkDeleteBody = z.infer<
+  typeof CategoryBulkDeleteBodySchema
+>;

--- a/src/routes/categories/category.service.ts
+++ b/src/routes/categories/category.service.ts
@@ -1,4 +1,4 @@
-import { and, asc, eq, isNotNull, isNull, sql } from "drizzle-orm";
+import { and, asc, eq, inArray, isNotNull, isNull, sql } from "drizzle-orm";
 import { MySql2Database } from "drizzle-orm/mysql2";
 import {
   Category,
@@ -54,6 +54,17 @@ export interface CategoryDeleteArgs {
   action: "move" | "trash";
   moveTo?: number;
 }
+
+/**
+ * Category 벌크 삭제 파라미터
+ */
+export interface CategoryBulkDeleteArgs {
+  ids: number[];
+  action: "move" | "trash";
+  moveTo?: number;
+}
+
+const MAX_BULK_DELETE_CATEGORIES = 100;
 
 /**
  * 게시글 카운트가 포함된 Category
@@ -396,6 +407,121 @@ export class CategoryService {
           .set({ parentId: item.parentId, sortOrder: item.sortOrder })
           .where(eq(categoryTable.id, item.id));
       }
+    });
+  }
+
+  /**
+   * 카테고리 벌크 삭제
+   * - 전체 대상 존재 여부와 하위 카테고리 여부를 먼저 검증
+   * - action=move: 미삭제 게시글은 moveTo로 이동, soft-deleted 게시글은 categoryId 초기화
+   * - action=trash: 미삭제 게시글은 soft delete + categoryId 초기화, soft-deleted 게시글은 categoryId 초기화
+   * - 검증/게시글 처리/카테고리 삭제를 단일 트랜잭션으로 수행
+   */
+  async deleteCategories(args: CategoryBulkDeleteArgs): Promise<void> {
+    const { ids, action, moveTo } = args;
+
+    if (ids.length === 0) {
+      throw HttpError.badRequest("At least one category ID is required.");
+    }
+
+    if (ids.length > MAX_BULK_DELETE_CATEGORIES) {
+      throw HttpError.badRequest(
+        `Cannot delete more than ${MAX_BULK_DELETE_CATEGORIES} categories at once.`,
+      );
+    }
+
+    const uniqueIds = [...new Set(ids)];
+    if (uniqueIds.length !== ids.length) {
+      throw HttpError.badRequest("Duplicate category IDs are not allowed.");
+    }
+
+    if (action === "move" && moveTo == null) {
+      throw HttpError.badRequest("moveTo is required when action is move.");
+    }
+
+    if (action === "move" && uniqueIds.includes(moveTo!)) {
+      throw HttpError.badRequest(
+        "moveTo cannot be one of the categories being deleted.",
+      );
+    }
+
+    await this.db.transaction(async (tx) => {
+      const categories = await tx
+        .select({ id: categoryTable.id })
+        .from(categoryTable)
+        .where(inArray(categoryTable.id, uniqueIds))
+        .for("update");
+
+      if (categories.length !== uniqueIds.length) {
+        throw HttpError.notFound("One or more categories not found.");
+      }
+
+      const [childCategory] = await tx
+        .select({ id: categoryTable.id })
+        .from(categoryTable)
+        .where(inArray(categoryTable.parentId, uniqueIds))
+        .limit(1);
+
+      if (childCategory) {
+        throw HttpError.conflict("Cannot delete category with subcategories.");
+      }
+
+      if (action === "move") {
+        const [targetCategory] = await tx
+          .select({ id: categoryTable.id })
+          .from(categoryTable)
+          .where(eq(categoryTable.id, moveTo!))
+          .limit(1)
+          .for("share");
+
+        if (!targetCategory) {
+          throw HttpError.badRequest("Target category not found.");
+        }
+
+        await tx
+          .update(postTable)
+          .set({ categoryId: moveTo! })
+          .where(
+            and(
+              inArray(postTable.categoryId, uniqueIds),
+              isNull(postTable.deletedAt),
+            ),
+          );
+
+        await tx
+          .update(postTable)
+          .set({ categoryId: null })
+          .where(
+            and(
+              inArray(postTable.categoryId, uniqueIds),
+              isNotNull(postTable.deletedAt),
+            ),
+          );
+      } else {
+        await tx
+          .update(postTable)
+          .set({ deletedAt: sql`NOW()`, categoryId: null })
+          .where(
+            and(
+              inArray(postTable.categoryId, uniqueIds),
+              isNull(postTable.deletedAt),
+            ),
+          );
+
+        await tx
+          .update(postTable)
+          .set({ categoryId: null })
+          .where(
+            and(
+              inArray(postTable.categoryId, uniqueIds),
+              isNotNull(postTable.deletedAt),
+            ),
+          );
+      }
+
+      await tx
+        .delete(categoryTable)
+        .where(inArray(categoryTable.id, uniqueIds));
     });
   }
 

--- a/test/routes/categories.test.ts
+++ b/test/routes/categories.test.ts
@@ -1,6 +1,6 @@
 import { FastifyInstance } from "fastify";
 import { describe, it, expect, beforeAll, afterAll, beforeEach } from "vitest";
-import { eq } from "drizzle-orm";
+import { eq, inArray } from "drizzle-orm";
 import { createTestApp, cleanup, injectAuth } from "@test/helpers/app";
 import {
   seedAdmin,
@@ -9,7 +9,7 @@ import {
   truncateAll,
 } from "@test/helpers/seed";
 import { db } from "@src/db/client";
-import { postTable } from "@src/db/schema";
+import { categoryTable, postTable } from "@src/db/schema";
 
 function expectRouteHasOnRequestHook(
   tree: string,
@@ -434,6 +434,274 @@ describe("Category Routes", () => {
       });
 
       expect(response.statusCode).toBe(400);
+    });
+  });
+
+  // ===== DELETE /categories/bulk =====
+
+  describe("DELETE /categories/bulk", () => {
+    it("route에 CSRF onRequest hook 등록", () => {
+      const routes = app.printRoutes({
+        commonPrefix: false,
+        includeHooks: true,
+        method: "DELETE",
+      });
+
+      expectRouteHasOnRequestHook(routes, "/categories/bulk", "DELETE");
+    });
+
+    it("비인증 → 403", async () => {
+      const response = await app.inject({
+        method: "DELETE",
+        url: "/categories/bulk",
+        payload: {
+          ids: [1],
+          action: "trash",
+        },
+      });
+
+      expect(response.statusCode).toBe(403);
+    });
+
+    it("빈 ids → 400", async () => {
+      await seedAdmin();
+      const cookie = await injectAuth(app);
+
+      const response = await app.inject({
+        method: "DELETE",
+        url: "/categories/bulk",
+        headers: { cookie },
+        payload: {
+          ids: [],
+          action: "trash",
+        },
+      });
+
+      expect(response.statusCode).toBe(400);
+    });
+
+    it("중복 ids → 400", async () => {
+      await seedAdmin();
+      const cookie = await injectAuth(app);
+      const category = await seedCategory({ name: "Duplicate Target" });
+
+      const response = await app.inject({
+        method: "DELETE",
+        url: "/categories/bulk",
+        headers: { cookie },
+        payload: {
+          ids: [category.id, category.id],
+          action: "trash",
+        },
+      });
+
+      expect(response.statusCode).toBe(400);
+    });
+
+    it("존재하지 않는 ids 포함 → 404 + 기존 카테고리 유지", async () => {
+      await seedAdmin();
+      const cookie = await injectAuth(app);
+      const category = await seedCategory({ name: "Existing Category" });
+
+      const response = await app.inject({
+        method: "DELETE",
+        url: "/categories/bulk",
+        headers: { cookie },
+        payload: {
+          ids: [category.id, 999999],
+          action: "trash",
+        },
+      });
+
+      expect(response.statusCode).toBe(404);
+
+      const [row] = await db
+        .select()
+        .from(categoryTable)
+        .where(eq(categoryTable.id, category.id));
+      expect(row).toBeDefined();
+    });
+
+    it("하위 카테고리 포함 시 → 409", async () => {
+      await seedAdmin();
+      const cookie = await injectAuth(app);
+      const parent = await seedCategory({ name: "Parent" });
+      await seedCategory({ name: "Child", parentId: parent.id });
+
+      const response = await app.inject({
+        method: "DELETE",
+        url: "/categories/bulk",
+        headers: { cookie },
+        payload: {
+          ids: [parent.id],
+          action: "trash",
+        },
+      });
+
+      expect(response.statusCode).toBe(409);
+    });
+
+    it("action=move moveTo 없으면 400", async () => {
+      await seedAdmin();
+      const cookie = await injectAuth(app);
+      const category = await seedCategory({ name: "Move Source" });
+
+      const response = await app.inject({
+        method: "DELETE",
+        url: "/categories/bulk",
+        headers: { cookie },
+        payload: {
+          ids: [category.id],
+          action: "move",
+        },
+      });
+
+      expect(response.statusCode).toBe(400);
+    });
+
+    it("action=move moveTo가 존재하지 않는 카테고리면 400", async () => {
+      await seedAdmin();
+      const cookie = await injectAuth(app);
+      const category = await seedCategory({ name: "Move Source" });
+
+      const response = await app.inject({
+        method: "DELETE",
+        url: "/categories/bulk",
+        headers: { cookie },
+        payload: {
+          ids: [category.id],
+          action: "move",
+          moveTo: 999999,
+        },
+      });
+
+      expect(response.statusCode).toBe(400);
+    });
+
+    it("action=move moveTo가 삭제 대상에 포함되면 400", async () => {
+      await seedAdmin();
+      const cookie = await injectAuth(app);
+      const source = await seedCategory({ name: "Move Source" });
+      const target = await seedCategory({ name: "Move Target" });
+
+      const response = await app.inject({
+        method: "DELETE",
+        url: "/categories/bulk",
+        headers: { cookie },
+        payload: {
+          ids: [source.id, target.id],
+          action: "move",
+          moveTo: target.id,
+        },
+      });
+
+      expect(response.statusCode).toBe(400);
+    });
+
+    it("action=trash: 게시글 휴지통 이동 후 삭제 → 204 + DB 검증", async () => {
+      await seedAdmin();
+      const cookie = await injectAuth(app);
+      const categoryA = await seedCategory({ name: "Trash Source A" });
+      const categoryB = await seedCategory({ name: "Trash Source B" });
+      const activePostA = await seedPost(categoryA.id);
+      const activePostB = await seedPost(categoryB.id);
+      const deletedPost = await seedPost(categoryB.id, {
+        deletedAt: new Date(),
+      });
+
+      const response = await app.inject({
+        method: "DELETE",
+        url: "/categories/bulk",
+        headers: { cookie },
+        payload: {
+          ids: [categoryA.id, categoryB.id],
+          action: "trash",
+        },
+      });
+
+      expect(response.statusCode).toBe(204);
+
+      const posts = await db
+        .select()
+        .from(postTable)
+        .where(
+          inArray(postTable.id, [
+            activePostA.id,
+            activePostB.id,
+            deletedPost.id,
+          ]),
+        );
+      const postById = new Map(posts.map((post) => [post.id, post]));
+
+      expect(postById.get(activePostA.id)?.deletedAt).not.toBeNull();
+      expect(postById.get(activePostA.id)?.categoryId).toBeNull();
+      expect(postById.get(activePostB.id)?.deletedAt).not.toBeNull();
+      expect(postById.get(activePostB.id)?.categoryId).toBeNull();
+      expect(postById.get(deletedPost.id)?.deletedAt).not.toBeNull();
+      expect(postById.get(deletedPost.id)?.categoryId).toBeNull();
+
+      const categories = await db
+        .select()
+        .from(categoryTable)
+        .where(inArray(categoryTable.id, [categoryA.id, categoryB.id]));
+      expect(categories).toHaveLength(0);
+    });
+
+    it("action=move: 게시글 이동 후 삭제 → 204 + DB 검증", async () => {
+      await seedAdmin();
+      const cookie = await injectAuth(app);
+      const target = await seedCategory({ name: "Move Target" });
+      const categoryA = await seedCategory({ name: "Move Source A" });
+      const categoryB = await seedCategory({ name: "Move Source B" });
+      const activePostA = await seedPost(categoryA.id);
+      const activePostB = await seedPost(categoryB.id);
+      const deletedPost = await seedPost(categoryB.id, {
+        deletedAt: new Date(),
+      });
+
+      const response = await app.inject({
+        method: "DELETE",
+        url: "/categories/bulk",
+        headers: { cookie },
+        payload: {
+          ids: [categoryA.id, categoryB.id],
+          action: "move",
+          moveTo: target.id,
+        },
+      });
+
+      expect(response.statusCode).toBe(204);
+
+      const posts = await db
+        .select()
+        .from(postTable)
+        .where(
+          inArray(postTable.id, [
+            activePostA.id,
+            activePostB.id,
+            deletedPost.id,
+          ]),
+        );
+      const postById = new Map(posts.map((post) => [post.id, post]));
+
+      expect(postById.get(activePostA.id)?.categoryId).toBe(target.id);
+      expect(postById.get(activePostA.id)?.deletedAt).toBeNull();
+      expect(postById.get(activePostB.id)?.categoryId).toBe(target.id);
+      expect(postById.get(activePostB.id)?.deletedAt).toBeNull();
+      expect(postById.get(deletedPost.id)?.categoryId).toBeNull();
+      expect(postById.get(deletedPost.id)?.deletedAt).not.toBeNull();
+
+      const deletedCategories = await db
+        .select()
+        .from(categoryTable)
+        .where(inArray(categoryTable.id, [categoryA.id, categoryB.id]));
+      expect(deletedCategories).toHaveLength(0);
+
+      const [targetCategory] = await db
+        .select()
+        .from(categoryTable)
+        .where(eq(categoryTable.id, target.id));
+      expect(targetCategory).toBeDefined();
     });
   });
 


### PR DESCRIPTION
## Summary

Closes #119

Adds a transactional admin bulk category deletion API so selected categories can be deleted in one request without partial database changes.

## Changes

| File | Change |
|------|--------|
| `src/routes/categories/category.schema.ts` | Added bulk delete body validation for IDs, max count, duplicates, action, and move target requirements. |
| `src/routes/categories/category.route.ts` | Registered `DELETE /categories/bulk` before `/:id` with admin auth and CSRF protection. |
| `src/routes/categories/category.service.ts` | Added transactional bulk delete logic that preserves existing move/trash post handling rules. |
| `test/routes/categories.test.ts` | Added coverage for auth/CSRF route wiring, validation failures, transaction safety, move/trash DB state, and `/bulk` static route matching. |

## Verification

- `pnpm compile:types`
- `pnpm lint`
- `pnpm test test/routes/categories.test.ts`
- `pnpm test`

## Screenshots

N/A - API only.
