### PR TITLE
chore: bump server version to 1.2.0

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "pyosh-blog-be",
-  "version": "1.1.5",
+  "version": "1.2.0",
   "repository": "https://github.com/pyo-sh/pyosh-blog-be.git",
   "license": "MIT",
   "author": "pyo-sh <pygosky@gmail.com>",


### PR DESCRIPTION
## Summary

Bump the server package version to `1.2.0` for the next backend release.

## Release contents

- Fix guestbook guest creation so `guestEmail` is optional for guest submissions (#117, #118)
- Add transactional admin category bulk delete API with validation and route/test coverage (#119, #120)

## Verification

- `pnpm compile:types`
- `pnpm lint`
- `pnpm test`

## Screenshots

N/A - API/release metadata only.
