### PR TITLE
feat: separate post search indexing (#123)

### DIFF
--- a/drizzle/0011_post_search_indexable.sql
+++ b/drizzle/0011_post_search_indexable.sql
@@ -1,0 +1,1 @@
+ALTER TABLE `post_tb` ADD `search_indexable` boolean NOT NULL DEFAULT true;

--- a/drizzle/meta/0011_snapshot.json
+++ b/drizzle/meta/0011_snapshot.json
@@ -1,0 +1,1038 @@
+{
+  "version": "5",
+  "dialect": "mysql",
+  "id": "b1e516ca-2812-43c3-97a7-37a51828a7e6",
+  "prevId": "bd618725-39b6-481b-8db8-9a41964925ad",
+  "tables": {
+    "session_tb": {
+      "name": "session_tb",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "varchar(128)",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "expires_at": {
+          "name": "expires_at",
+          "type": "int",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "data": {
+          "name": "data",
+          "type": "varchar(2048)",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {},
+      "compositePrimaryKeys": {
+        "session_tb_id": {
+          "name": "session_tb_id",
+          "columns": [
+            "id"
+          ]
+        }
+      },
+      "uniqueConstraints": {},
+      "checkConstraint": {}
+    },
+    "admin_tb": {
+      "name": "admin_tb",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "int",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": true
+        },
+        "email": {
+          "name": "email",
+          "type": "varchar(100)",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "password_hash": {
+          "name": "password_hash",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "(now())"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "onUpdate": true,
+          "default": "(now())"
+        },
+        "last_login_at": {
+          "name": "last_login_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {},
+      "compositePrimaryKeys": {
+        "admin_tb_id": {
+          "name": "admin_tb_id",
+          "columns": [
+            "id"
+          ]
+        }
+      },
+      "uniqueConstraints": {
+        "admin_tb_email_unique": {
+          "name": "admin_tb_email_unique",
+          "columns": [
+            "email"
+          ]
+        }
+      },
+      "checkConstraint": {}
+    },
+    "oauth_account_tb": {
+      "name": "oauth_account_tb",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "int",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": true
+        },
+        "provider": {
+          "name": "provider",
+          "type": "enum('github','google')",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "provider_user_id": {
+          "name": "provider_user_id",
+          "type": "varchar(100)",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "email": {
+          "name": "email",
+          "type": "varchar(100)",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "display_name": {
+          "name": "display_name",
+          "type": "varchar(100)",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "avatar_url": {
+          "name": "avatar_url",
+          "type": "varchar(500)",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "(now())"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "onUpdate": true,
+          "default": "(now())"
+        },
+        "deleted_at": {
+          "name": "deleted_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        }
+      },
+      "indexes": {
+        "provider_user_idx": {
+          "name": "provider_user_idx",
+          "columns": [
+            "provider",
+            "provider_user_id"
+          ],
+          "isUnique": true
+        }
+      },
+      "foreignKeys": {},
+      "compositePrimaryKeys": {
+        "oauth_account_tb_id": {
+          "name": "oauth_account_tb_id",
+          "columns": [
+            "id"
+          ]
+        }
+      },
+      "uniqueConstraints": {},
+      "checkConstraint": {}
+    },
+    "category_tb": {
+      "name": "category_tb",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "int",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": true
+        },
+        "parent_id": {
+          "name": "parent_id",
+          "type": "int",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "name": {
+          "name": "name",
+          "type": "varchar(50)",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "slug": {
+          "name": "slug",
+          "type": "varchar(100)",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "sort_order": {
+          "name": "sort_order",
+          "type": "int",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": 0
+        },
+        "is_visible": {
+          "name": "is_visible",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": true
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "(now())"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "onUpdate": true,
+          "default": "(now())"
+        }
+      },
+      "indexes": {
+        "parent_id_idx": {
+          "name": "parent_id_idx",
+          "columns": [
+            "parent_id"
+          ],
+          "isUnique": false
+        },
+        "sort_order_idx": {
+          "name": "sort_order_idx",
+          "columns": [
+            "sort_order"
+          ],
+          "isUnique": false
+        }
+      },
+      "foreignKeys": {},
+      "compositePrimaryKeys": {
+        "category_tb_id": {
+          "name": "category_tb_id",
+          "columns": [
+            "id"
+          ]
+        }
+      },
+      "uniqueConstraints": {
+        "category_tb_slug_unique": {
+          "name": "category_tb_slug_unique",
+          "columns": [
+            "slug"
+          ]
+        }
+      },
+      "checkConstraint": {}
+    },
+    "tag_tb": {
+      "name": "tag_tb",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "int",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": true
+        },
+        "name": {
+          "name": "name",
+          "type": "varchar(30)",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "slug": {
+          "name": "slug",
+          "type": "varchar(50)",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "(now())"
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {},
+      "compositePrimaryKeys": {
+        "tag_tb_id": {
+          "name": "tag_tb_id",
+          "columns": [
+            "id"
+          ]
+        }
+      },
+      "uniqueConstraints": {
+        "tag_tb_name_unique": {
+          "name": "tag_tb_name_unique",
+          "columns": [
+            "name"
+          ]
+        },
+        "tag_tb_slug_unique": {
+          "name": "tag_tb_slug_unique",
+          "columns": [
+            "slug"
+          ]
+        }
+      },
+      "checkConstraint": {}
+    },
+    "asset_tb": {
+      "name": "asset_tb",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "int",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": true
+        },
+        "storage_provider": {
+          "name": "storage_provider",
+          "type": "varchar(20)",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "'local'"
+        },
+        "storage_key": {
+          "name": "storage_key",
+          "type": "varchar(500)",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "mime_type": {
+          "name": "mime_type",
+          "type": "varchar(100)",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "size_bytes": {
+          "name": "size_bytes",
+          "type": "int",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "width": {
+          "name": "width",
+          "type": "int",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "height": {
+          "name": "height",
+          "type": "int",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "(now())"
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {},
+      "compositePrimaryKeys": {
+        "asset_tb_id": {
+          "name": "asset_tb_id",
+          "columns": [
+            "id"
+          ]
+        }
+      },
+      "uniqueConstraints": {},
+      "checkConstraint": {}
+    },
+    "post_tb": {
+      "name": "post_tb",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "int",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": true
+        },
+        "category_id": {
+          "name": "category_id",
+          "type": "int",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "title": {
+          "name": "title",
+          "type": "varchar(200)",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "slug": {
+          "name": "slug",
+          "type": "varchar(200)",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "content_md": {
+          "name": "content_md",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "thumbnail_url": {
+          "name": "thumbnail_url",
+          "type": "varchar(500)",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "visibility": {
+          "name": "visibility",
+          "type": "enum('public','private')",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "'public'"
+        },
+        "search_indexable": {
+          "name": "search_indexable",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "true"
+        },
+        "status": {
+          "name": "status",
+          "type": "enum('draft','published','archived')",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "'draft'"
+        },
+        "published_at": {
+          "name": "published_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "(now())"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "onUpdate": true,
+          "default": "(now())"
+        },
+        "deleted_at": {
+          "name": "deleted_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "summary": {
+          "name": "summary",
+          "type": "varchar(200)",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "description": {
+          "name": "description",
+          "type": "varchar(300)",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "comment_status": {
+          "name": "comment_status",
+          "type": "enum('open','locked','disabled')",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "'open'"
+        },
+        "is_pinned": {
+          "name": "is_pinned",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "false"
+        },
+        "content_modified_at": {
+          "name": "content_modified_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        }
+      },
+      "indexes": {
+        "category_published_idx": {
+          "name": "category_published_idx",
+          "columns": [
+            "category_id",
+            "published_at"
+          ],
+          "isUnique": false
+        },
+        "status_published_idx": {
+          "name": "status_published_idx",
+          "columns": [
+            "status",
+            "published_at"
+          ],
+          "isUnique": false
+        }
+      },
+      "foreignKeys": {},
+      "compositePrimaryKeys": {
+        "post_tb_id": {
+          "name": "post_tb_id",
+          "columns": [
+            "id"
+          ]
+        }
+      },
+      "uniqueConstraints": {
+        "post_tb_slug_unique": {
+          "name": "post_tb_slug_unique",
+          "columns": [
+            "slug"
+          ]
+        }
+      },
+      "checkConstraint": {}
+    },
+    "post_tag_tb": {
+      "name": "post_tag_tb",
+      "columns": {
+        "post_id": {
+          "name": "post_id",
+          "type": "int",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "tag_id": {
+          "name": "tag_id",
+          "type": "int",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        }
+      },
+      "indexes": {
+        "tag_id_idx": {
+          "name": "tag_id_idx",
+          "columns": [
+            "tag_id"
+          ],
+          "isUnique": false
+        }
+      },
+      "foreignKeys": {},
+      "compositePrimaryKeys": {
+        "post_tag_tb_post_id_tag_id_pk": {
+          "name": "post_tag_tb_post_id_tag_id_pk",
+          "columns": [
+            "post_id",
+            "tag_id"
+          ]
+        }
+      },
+      "uniqueConstraints": {},
+      "checkConstraint": {}
+    },
+    "comment_tb": {
+      "name": "comment_tb",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "int",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": true
+        },
+        "post_id": {
+          "name": "post_id",
+          "type": "int",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "parent_id": {
+          "name": "parent_id",
+          "type": "int",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "depth": {
+          "name": "depth",
+          "type": "int",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": 0
+        },
+        "reply_to_comment_id": {
+          "name": "reply_to_comment_id",
+          "type": "int",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "reply_to_name": {
+          "name": "reply_to_name",
+          "type": "varchar(50)",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "author_type": {
+          "name": "author_type",
+          "type": "enum('oauth','guest')",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "oauth_account_id": {
+          "name": "oauth_account_id",
+          "type": "int",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "guest_name": {
+          "name": "guest_name",
+          "type": "varchar(50)",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "guest_email": {
+          "name": "guest_email",
+          "type": "varchar(100)",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "guest_password_hash": {
+          "name": "guest_password_hash",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "body": {
+          "name": "body",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "is_secret": {
+          "name": "is_secret",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": false
+        },
+        "status": {
+          "name": "status",
+          "type": "enum('active','deleted','hidden')",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "'active'"
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "(now())"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "onUpdate": true,
+          "default": "(now())"
+        },
+        "deleted_at": {
+          "name": "deleted_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        }
+      },
+      "indexes": {
+        "post_parent_created_idx": {
+          "name": "post_parent_created_idx",
+          "columns": [
+            "post_id",
+            "parent_id",
+            "created_at"
+          ],
+          "isUnique": false
+        },
+        "oauth_account_idx": {
+          "name": "oauth_account_idx",
+          "columns": [
+            "oauth_account_id"
+          ],
+          "isUnique": false
+        },
+        "status_idx": {
+          "name": "status_idx",
+          "columns": [
+            "status"
+          ],
+          "isUnique": false
+        }
+      },
+      "foreignKeys": {},
+      "compositePrimaryKeys": {
+        "comment_tb_id": {
+          "name": "comment_tb_id",
+          "columns": [
+            "id"
+          ]
+        }
+      },
+      "uniqueConstraints": {},
+      "checkConstraint": {}
+    },
+    "guestbook_entry_tb": {
+      "name": "guestbook_entry_tb",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "int",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": true
+        },
+        "parent_id": {
+          "name": "parent_id",
+          "type": "int",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "author_type": {
+          "name": "author_type",
+          "type": "enum('oauth','guest')",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "oauth_account_id": {
+          "name": "oauth_account_id",
+          "type": "int",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "guest_name": {
+          "name": "guest_name",
+          "type": "varchar(50)",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "guest_email": {
+          "name": "guest_email",
+          "type": "varchar(100)",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "guest_password_hash": {
+          "name": "guest_password_hash",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "body": {
+          "name": "body",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "is_secret": {
+          "name": "is_secret",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": false
+        },
+        "status": {
+          "name": "status",
+          "type": "enum('active','deleted','hidden')",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "'active'"
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "(now())"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "onUpdate": true,
+          "default": "(now())"
+        },
+        "deleted_at": {
+          "name": "deleted_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        }
+      },
+      "indexes": {
+        "parent_id_idx": {
+          "name": "parent_id_idx",
+          "columns": [
+            "parent_id"
+          ],
+          "isUnique": false
+        },
+        "oauth_account_idx": {
+          "name": "oauth_account_idx",
+          "columns": [
+            "oauth_account_id"
+          ],
+          "isUnique": false
+        },
+        "status_idx": {
+          "name": "status_idx",
+          "columns": [
+            "status"
+          ],
+          "isUnique": false
+        }
+      },
+      "foreignKeys": {},
+      "compositePrimaryKeys": {
+        "guestbook_entry_tb_id": {
+          "name": "guestbook_entry_tb_id",
+          "columns": [
+            "id"
+          ]
+        }
+      },
+      "uniqueConstraints": {},
+      "checkConstraint": {}
+    },
+    "stats_daily_tb": {
+      "name": "stats_daily_tb",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "int",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": true
+        },
+        "post_id": {
+          "name": "post_id",
+          "type": "int",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "date": {
+          "name": "date",
+          "type": "date",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "pageviews": {
+          "name": "pageviews",
+          "type": "int",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": 0
+        },
+        "uniques": {
+          "name": "uniques",
+          "type": "int",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": 0
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "(now())"
+        }
+      },
+      "indexes": {
+        "post_date_idx": {
+          "name": "post_date_idx",
+          "columns": [
+            "post_id",
+            "date"
+          ],
+          "isUnique": true
+        }
+      },
+      "foreignKeys": {},
+      "compositePrimaryKeys": {
+        "stats_daily_tb_id": {
+          "name": "stats_daily_tb_id",
+          "columns": [
+            "id"
+          ]
+        }
+      },
+      "uniqueConstraints": {},
+      "checkConstraint": {}
+    }
+  },
+  "views": {},
+  "_meta": {
+    "schemas": {},
+    "tables": {},
+    "columns": {}
+  },
+  "internal": {
+    "tables": {},
+    "indexes": {}
+  }
+}

--- a/drizzle/meta/_journal.json
+++ b/drizzle/meta/_journal.json
@@ -78,6 +78,13 @@
       "when": 1776560400000,
       "tag": "0010_site_settings_backfill",
       "breakpoints": true
+    },
+    {
+      "idx": 11,
+      "version": "5",
+      "when": 1777791600000,
+      "tag": "0011_post_search_indexable",
+      "breakpoints": true
     }
   ]
 }

--- a/src/db/schema/posts.ts
+++ b/src/db/schema/posts.ts
@@ -26,6 +26,7 @@ export const postTable = mysqlTable(
     visibility: mysqlEnum("visibility", ["public", "private"])
       .default("public")
       .notNull(),
+    searchIndexable: boolean("search_indexable").default(true).notNull(),
     status: mysqlEnum("status", ["draft", "published", "archived"])
       .default("draft")
       .notNull(),

--- a/src/routes/comments/comment.route.ts
+++ b/src/routes/comments/comment.route.ts
@@ -50,6 +50,7 @@ export function createCommentRoute(
           response: {
             200: CommentsResponseSchema,
             400: ErrorResponseSchema,
+            404: ErrorResponseSchema,
           },
         },
         preHandler: optionalAuth,
@@ -100,6 +101,7 @@ export function createCommentRoute(
           response: {
             201: CreateCommentResponseSchema,
             400: ErrorResponseSchema,
+            404: ErrorResponseSchema,
             429: ErrorResponseSchema,
           },
         },

--- a/src/routes/comments/comment.service.ts
+++ b/src/routes/comments/comment.service.ts
@@ -21,6 +21,7 @@ import * as schema from "@src/db/schema/index";
 import { oauthAccountTable } from "@src/db/schema/oauth-accounts";
 import { postTable } from "@src/db/schema/posts";
 import { HttpError } from "@src/errors/http-error";
+import { buildPublicReadablePostWhere } from "@src/routes/posts/post.visibility";
 import {
   Author,
   buildHierarchy,
@@ -105,9 +106,9 @@ export class CommentService {
     return await this.db.transaction(async (tx) => {
       // 1. 게시글 존재 확인 (삭제되지 않은 것)
       const [post] = await tx
-        .select()
+        .select({ id: postTable.id })
         .from(postTable)
-        .where(and(eq(postTable.id, postId), isNull(postTable.deletedAt)))
+        .where(buildPublicReadablePostWhere(eq(postTable.id, postId)))
         .limit(1);
 
       if (!post) {
@@ -267,6 +268,8 @@ export class CommentService {
       throw HttpError.notFound("Comment not found.");
     }
 
+    await this.assertPublicReadablePost(comment.postId);
+
     if (comment.status !== "active" || comment.deletedAt !== null) {
       throw HttpError.notFound("Comment not found.");
     }
@@ -307,6 +310,8 @@ export class CommentService {
     const offset = calculateOffset(page, limit);
     const viewerUserId = options?.viewerUserId ?? null;
     const isAdmin = options?.viewerIsAdmin ?? false;
+
+    await this.assertPublicReadablePost(postId);
 
     const activeCondition = and(
       eq(commentTable.postId, postId),
@@ -710,6 +715,18 @@ export class CommentService {
         }
         await tx.delete(commentTable).where(inArray(commentTable.id, ids));
       });
+    }
+  }
+
+  private async assertPublicReadablePost(postId: number): Promise<void> {
+    const [post] = await this.db
+      .select({ id: postTable.id })
+      .from(postTable)
+      .where(buildPublicReadablePostWhere(eq(postTable.id, postId)))
+      .limit(1);
+
+    if (!post) {
+      throw HttpError.notFound("Post not found.");
     }
   }
 

--- a/src/routes/posts/post.route.ts
+++ b/src/routes/posts/post.route.ts
@@ -288,6 +288,7 @@ export function createAdminPostRoute(
           description: body.description,
           thumbnailUrl: body.thumbnailUrl,
           visibility: body.visibility,
+          searchIndexable: body.searchIndexable,
           status: body.status,
           commentStatus: body.commentStatus,
           isPinned: body.isPinned,

--- a/src/routes/posts/post.schema.ts
+++ b/src/routes/posts/post.schema.ts
@@ -176,6 +176,11 @@ export const CreatePostBodySchema = z.object({
     .optional()
     .default("public")
     .describe("공개 범위"),
+  searchIndexable: z
+    .boolean()
+    .optional()
+    .default(true)
+    .describe("검색엔진 색인 허용 여부"),
   status: z
     .enum(["draft", "published", "archived"])
     .optional()
@@ -216,6 +221,7 @@ export const UpdatePostBodySchema = z.object({
     .describe("SEO 메타 설명"),
   thumbnailUrl: ThumbnailUrlInputSchema.optional().describe("썸네일 URL"),
   visibility: z.enum(["public", "private"]).optional().describe("공개 범위"),
+  searchIndexable: z.boolean().optional().describe("검색엔진 색인 허용 여부"),
   status: z
     .enum(["draft", "published", "archived"])
     .optional()
@@ -307,6 +313,7 @@ const PostBaseFields = {
   description: z.string().nullable().describe("SEO 메타 설명"),
   thumbnailUrl: z.string().nullable().describe("썸네일 URL"),
   visibility: z.enum(["public", "private"]).describe("공개 범위"),
+  searchIndexable: z.boolean().describe("검색엔진 색인 허용 여부"),
   status: z.enum(["draft", "published", "archived"]).describe("게시 상태"),
   commentStatus: z
     .enum(["open", "locked", "disabled"])

--- a/src/routes/posts/post.service.ts
+++ b/src/routes/posts/post.service.ts
@@ -23,6 +23,10 @@ import { Post, postTable, NewPost } from "@src/db/schema/posts";
 import { statsDailyTable } from "@src/db/schema/stats";
 import { tagTable } from "@src/db/schema/tags";
 import { HttpError } from "@src/errors/http-error";
+import {
+  buildPublicReadablePostWhere,
+  buildSearchIndexablePostWhere,
+} from "@src/routes/posts/post.visibility";
 import { TagService } from "@src/routes/tags/tag.service";
 import {
   buildPaginatedResponse,
@@ -101,6 +105,7 @@ export interface CreatePostInput {
   description?: string;
   thumbnailUrl?: string | null;
   visibility?: "public" | "private";
+  searchIndexable?: boolean;
   status?: "draft" | "published" | "archived";
   commentStatus?: "open" | "locked" | "disabled";
   isPinned?: boolean;
@@ -119,6 +124,7 @@ export interface UpdatePostInput {
   description?: string | null;
   thumbnailUrl?: string | null;
   visibility?: "public" | "private";
+  searchIndexable?: boolean;
   status?: "draft" | "published" | "archived";
   commentStatus?: "open" | "locked" | "disabled";
   isPinned?: boolean;
@@ -270,6 +276,7 @@ export class PostService {
           description: input.description ?? null,
           thumbnailUrl: input.thumbnailUrl ?? null,
           visibility: input.visibility ?? "public",
+          searchIndexable: input.searchIndexable ?? true,
           status: input.status ?? "draft",
           commentStatus: input.commentStatus ?? "open",
           isPinned: input.isPinned ?? false,
@@ -636,7 +643,7 @@ export class PostService {
     const [post] = await this.db
       .select()
       .from(postTable)
-      .where(and(eq(postTable.slug, slug), isNull(postTable.deletedAt)))
+      .where(buildPublicReadablePostWhere(eq(postTable.slug, slug)))
       .limit(1);
 
     if (!post) {
@@ -655,8 +662,7 @@ export class PostService {
       .where(
         and(
           lt(postTable.publishedAt, post.publishedAt),
-          eq(postTable.status, "published"),
-          isNull(postTable.deletedAt),
+          buildPublicReadablePostWhere(),
         ),
       )
       .orderBy(desc(postTable.publishedAt))
@@ -672,8 +678,7 @@ export class PostService {
       .where(
         and(
           gt(postTable.publishedAt, post.publishedAt),
-          eq(postTable.status, "published"),
-          isNull(postTable.deletedAt),
+          buildPublicReadablePostWhere(),
         ),
       )
       .orderBy(asc(postTable.publishedAt))
@@ -694,13 +699,7 @@ export class PostService {
       // Google Sitemap 50,000 URLs/file 제한에 맞춰 현재는 상한을 둔다.
       .select({ slug: postTable.slug, updatedAt: postTable.updatedAt })
       .from(postTable)
-      .where(
-        and(
-          eq(postTable.status, "published"),
-          eq(postTable.visibility, "public"),
-          isNull(postTable.deletedAt),
-        ),
-      )
+      .where(buildSearchIndexablePostWhere())
       .orderBy(desc(postTable.updatedAt))
       .limit(50000);
 
@@ -1286,27 +1285,23 @@ export class PostService {
     }
 
     if (post.categoryId === null) {
-      const [postTags, totalPageviews, commentCount] = await Promise.all([
-        tx
-          .select({ id: tagTable.id, name: tagTable.name, slug: tagTable.slug })
-          .from(postTagTable)
-          .innerJoin(tagTable, eq(postTagTable.tagId, tagTable.id))
-          .where(eq(postTagTable.postId, post.id)),
-        tx
-          .select({
-            total: sql<number>`COALESCE(SUM(${statsDailyTable.pageviews}), 0)`,
-          })
-          .from(statsDailyTable)
-          .where(eq(statsDailyTable.postId, post.id))
-          .then((rows) => Number(rows[0]?.total ?? 0)),
-        tx
-          .select({ count: sql<number>`COUNT(*)` })
-          .from(commentTable)
-          .where(
-            this.buildVisibleCommentWhere(eq(commentTable.postId, post.id)),
-          )
-          .then((rows) => Number(rows[0]?.count ?? 0)),
-      ]);
+      const postTags = await tx
+        .select({ id: tagTable.id, name: tagTable.name, slug: tagTable.slug })
+        .from(postTagTable)
+        .innerJoin(tagTable, eq(postTagTable.tagId, tagTable.id))
+        .where(eq(postTagTable.postId, post.id));
+      const [pageviewRow] = await tx
+        .select({
+          total: sql<number>`COALESCE(SUM(${statsDailyTable.pageviews}), 0)`,
+        })
+        .from(statsDailyTable)
+        .where(eq(statsDailyTable.postId, post.id));
+      const [commentRow] = await tx
+        .select({ count: sql<number>`COUNT(*)` })
+        .from(commentTable)
+        .where(this.buildVisibleCommentWhere(eq(commentTable.postId, post.id)));
+      const totalPageviews = Number(pageviewRow?.total ?? 0);
+      const commentCount = Number(commentRow?.count ?? 0);
 
       return {
         ...post,
@@ -1317,39 +1312,33 @@ export class PostService {
       };
     }
 
-    const [category, postTags, totalPageviews, commentCount, ancestors] =
-      await Promise.all([
-        tx
-          .select({
-            id: categoryTable.id,
-            name: categoryTable.name,
-            slug: categoryTable.slug,
-          })
-          .from(categoryTable)
-          .where(eq(categoryTable.id, post.categoryId))
-          .limit(1)
-          .then((rows) => rows[0]),
-        tx
-          .select({ id: tagTable.id, name: tagTable.name, slug: tagTable.slug })
-          .from(postTagTable)
-          .innerJoin(tagTable, eq(postTagTable.tagId, tagTable.id))
-          .where(eq(postTagTable.postId, post.id)),
-        tx
-          .select({
-            total: sql<number>`COALESCE(SUM(${statsDailyTable.pageviews}), 0)`,
-          })
-          .from(statsDailyTable)
-          .where(eq(statsDailyTable.postId, post.id))
-          .then((rows) => Number(rows[0]?.total ?? 0)),
-        tx
-          .select({ count: sql<number>`COUNT(*)` })
-          .from(commentTable)
-          .where(
-            this.buildVisibleCommentWhere(eq(commentTable.postId, post.id)),
-          )
-          .then((rows) => Number(rows[0]?.count ?? 0)),
-        this.fetchCategoryAncestors(post.categoryId, tx),
-      ]);
+    const [category] = await tx
+      .select({
+        id: categoryTable.id,
+        name: categoryTable.name,
+        slug: categoryTable.slug,
+      })
+      .from(categoryTable)
+      .where(eq(categoryTable.id, post.categoryId))
+      .limit(1);
+    const postTags = await tx
+      .select({ id: tagTable.id, name: tagTable.name, slug: tagTable.slug })
+      .from(postTagTable)
+      .innerJoin(tagTable, eq(postTagTable.tagId, tagTable.id))
+      .where(eq(postTagTable.postId, post.id));
+    const [pageviewRow] = await tx
+      .select({
+        total: sql<number>`COALESCE(SUM(${statsDailyTable.pageviews}), 0)`,
+      })
+      .from(statsDailyTable)
+      .where(eq(statsDailyTable.postId, post.id));
+    const [commentRow] = await tx
+      .select({ count: sql<number>`COUNT(*)` })
+      .from(commentTable)
+      .where(this.buildVisibleCommentWhere(eq(commentTable.postId, post.id)));
+    const ancestors = await this.fetchCategoryAncestors(post.categoryId, tx);
+    const totalPageviews = Number(pageviewRow?.total ?? 0);
+    const commentCount = Number(commentRow?.count ?? 0);
 
     if (!category)
       throw HttpError.notFound(

--- a/src/routes/posts/post.visibility.ts
+++ b/src/routes/posts/post.visibility.ts
@@ -1,0 +1,30 @@
+import { and, eq, isNull, SQL } from "drizzle-orm";
+import { postTable } from "@src/db/schema/posts";
+
+function compactConditions(
+  conditions: Array<SQL<unknown> | undefined>,
+): Array<SQL<unknown>> {
+  return conditions.filter(
+    (condition): condition is SQL<unknown> => condition !== undefined,
+  );
+}
+
+export function buildPublicReadablePostWhere(
+  ...conditions: Array<SQL<unknown> | undefined>
+): SQL<unknown> {
+  return and(
+    ...compactConditions(conditions),
+    eq(postTable.status, "published"),
+    eq(postTable.visibility, "public"),
+    isNull(postTable.deletedAt),
+  )!;
+}
+
+export function buildSearchIndexablePostWhere(
+  ...conditions: Array<SQL<unknown> | undefined>
+): SQL<unknown> {
+  return and(
+    buildPublicReadablePostWhere(...conditions),
+    eq(postTable.searchIndexable, true),
+  )!;
+}

--- a/src/routes/seo/seo.route.ts
+++ b/src/routes/seo/seo.route.ts
@@ -1,8 +1,12 @@
-import { and, desc, eq, isNull } from "drizzle-orm";
+import { desc, eq } from "drizzle-orm";
 import { FastifyInstance, FastifyPluginAsync } from "fastify";
 import { ZodTypeProvider } from "fastify-type-provider-zod";
 import { categoryTable } from "@src/db/schema/categories";
 import { postTable } from "@src/db/schema/posts";
+import {
+  buildPublicReadablePostWhere,
+  buildSearchIndexablePostWhere,
+} from "@src/routes/posts/post.visibility";
 import { env } from "@src/shared/env";
 
 const SITEMAP_CACHE_CONTROL = "public, max-age=3600";
@@ -63,13 +67,7 @@ export function createSeoRoute(): FastifyPluginAsync {
             updatedAt: postTable.updatedAt,
           })
           .from(postTable)
-          .where(
-            and(
-              eq(postTable.status, "published"),
-              eq(postTable.visibility, "public"),
-              isNull(postTable.deletedAt),
-            ),
-          )
+          .where(buildSearchIndexablePostWhere())
           .orderBy(desc(postTable.updatedAt));
 
         const categories = await fastify.db
@@ -137,13 +135,7 @@ export function createSeoRoute(): FastifyPluginAsync {
           })
           .from(postTable)
           .innerJoin(categoryTable, eq(postTable.categoryId, categoryTable.id))
-          .where(
-            and(
-              eq(postTable.status, "published"),
-              eq(postTable.visibility, "public"),
-              isNull(postTable.deletedAt),
-            ),
-          )
+          .where(buildPublicReadablePostWhere())
           .orderBy(desc(postTable.publishedAt), desc(postTable.updatedAt))
           .limit(RSS_LIMIT);
 

--- a/src/services/stats.service.ts
+++ b/src/services/stats.service.ts
@@ -5,6 +5,7 @@ import * as schema from "@src/db/schema/index";
 import { postTable } from "@src/db/schema/posts";
 import { statsDailyTable } from "@src/db/schema/stats";
 import { HttpError } from "@src/errors/http-error";
+import { buildPublicReadablePostWhere } from "@src/routes/posts/post.visibility";
 
 export interface PopularPostStat {
   postId: number;
@@ -50,14 +51,7 @@ export class StatsService {
       const [post] = await this.db
         .select({ id: postTable.id })
         .from(postTable)
-        .where(
-          and(
-            eq(postTable.id, postId),
-            eq(postTable.status, "published"),
-            eq(postTable.visibility, "public"),
-            isNull(postTable.deletedAt),
-          ),
-        )
+        .where(buildPublicReadablePostWhere(eq(postTable.id, postId)))
         .limit(1);
 
       if (!post) {
@@ -155,9 +149,7 @@ export class StatsService {
       .where(
         and(
           gte(statsDailyTable.date, fromDate),
-          eq(postTable.status, "published"),
-          eq(postTable.visibility, "public"),
-          isNull(postTable.deletedAt),
+          buildPublicReadablePostWhere(),
         ),
       )
       .groupBy(postTable.id, postTable.slug, postTable.title)

--- a/test/routes/comments.test.ts
+++ b/test/routes/comments.test.ts
@@ -122,6 +122,46 @@ describe("Comment Routes", () => {
       expect(body.data.depth).toBe(0);
     });
 
+    it("private 게시글에는 댓글을 작성할 수 없다 → 404", async () => {
+      const category = await seedCategory();
+      const post = await seedPost(category.id, {
+        status: "published",
+        visibility: "private",
+      });
+
+      const response = await app.inject({
+        method: "POST",
+        url: `/posts/${post.id}/comments`,
+        payload: {
+          body: "비공개 글 댓글",
+          guestName: "홍길동",
+          guestPassword: "pass1234",
+        },
+      });
+
+      expect(response.statusCode).toBe(404);
+    });
+
+    it("draft 게시글에는 댓글을 작성할 수 없다 → 404", async () => {
+      const category = await seedCategory();
+      const post = await seedPost(category.id, {
+        status: "draft",
+        visibility: "public",
+      });
+
+      const response = await app.inject({
+        method: "POST",
+        url: `/posts/${post.id}/comments`,
+        payload: {
+          body: "초안 글 댓글",
+          guestName: "홍길동",
+          guestPassword: "pass1234",
+        },
+      });
+
+      expect(response.statusCode).toBe(404);
+    });
+
     it("대댓글 (depth=1) 작성 → 201", async () => {
       const category = await seedCategory();
       const post = await seedPost(category.id, {
@@ -316,6 +356,38 @@ describe("Comment Routes", () => {
       expect(page2.statusCode).toBe(200);
       const page2Body = page2.json();
       expect(page2Body.data).toHaveLength(1);
+    });
+
+    it("private 게시글 댓글 목록은 조회할 수 없다 → 404", async () => {
+      const category = await seedCategory();
+      const post = await seedPost(category.id, {
+        status: "published",
+        visibility: "private",
+      });
+      await seedComment(post.id, { body: "숨겨진 댓글" });
+
+      const response = await app.inject({
+        method: "GET",
+        url: `/posts/${post.id}/comments`,
+      });
+
+      expect(response.statusCode).toBe(404);
+    });
+
+    it("archived 게시글 댓글 목록은 조회할 수 없다 → 404", async () => {
+      const category = await seedCategory();
+      const post = await seedPost(category.id, {
+        status: "archived",
+        visibility: "public",
+      });
+      await seedComment(post.id, { body: "보관 글 댓글" });
+
+      const response = await app.inject({
+        method: "GET",
+        url: `/posts/${post.id}/comments`,
+      });
+
+      expect(response.statusCode).toBe(404);
     });
 
     it("비밀 댓글 마스킹 확인", async () => {

--- a/test/routes/posts.test.ts
+++ b/test/routes/posts.test.ts
@@ -395,6 +395,28 @@ describe("Post Routes", () => {
       expect(body.meta).toBeDefined();
     });
 
+    it("searchIndexable=false 공개 글도 목록에 포함된다", async () => {
+      const category = await seedCategory();
+      const post = await seedPost(category.id, {
+        title: "Noindex Public Post",
+        status: "published",
+        visibility: "public",
+        searchIndexable: false,
+      });
+
+      const response = await app.inject({
+        method: "GET",
+        url: "/posts",
+      });
+
+      expect(response.statusCode).toBe(200);
+      expect(response.json().data).toHaveLength(1);
+      expect(response.json().data[0]).toMatchObject({
+        id: post.id,
+        searchIndexable: false,
+      });
+    });
+
     it("페이지네이션 동작 — limit=2, 총 3개 → 2개 반환", async () => {
       const category = await seedCategory();
 
@@ -611,6 +633,91 @@ describe("Post Routes", () => {
       expect(body.prevPost.slug).toBe(past.slug);
       expect(body.nextPost).not.toBeNull();
       expect(body.nextPost.slug).toBe(future.slug);
+    });
+
+    it("searchIndexable=false 공개 글도 상세 조회된다", async () => {
+      const category = await seedCategory();
+      const post = await seedPost(category.id, {
+        status: "published",
+        visibility: "public",
+        searchIndexable: false,
+      });
+
+      const response = await app.inject({
+        method: "GET",
+        url: `/posts/${post.slug}`,
+      });
+
+      expect(response.statusCode).toBe(200);
+      expect(response.json().post.searchIndexable).toBe(false);
+    });
+
+    it("private published 글은 관리자 쿠키가 있어도 404", async () => {
+      await seedAdmin();
+      const cookie = await injectAuth(app);
+      const category = await seedCategory();
+      const post = await seedPost(category.id, {
+        status: "published",
+        visibility: "private",
+      });
+
+      const anonymousResponse = await app.inject({
+        method: "GET",
+        url: `/posts/${post.slug}`,
+      });
+      const adminResponse = await app.inject({
+        method: "GET",
+        url: `/posts/${post.slug}`,
+        headers: { cookie },
+      });
+
+      expect(anonymousResponse.statusCode).toBe(404);
+      expect(adminResponse.statusCode).toBe(404);
+    });
+
+    it("이전/다음 글은 public readable 글만 반환한다", async () => {
+      const category = await seedCategory();
+      const now = Date.now();
+
+      await seedPost(category.id, {
+        title: "Private Past",
+        status: "published",
+        visibility: "private",
+        publishedAt: new Date(now - 7200000),
+      });
+      const publicPast = await seedPost(category.id, {
+        title: "Public Past",
+        status: "published",
+        visibility: "public",
+        publishedAt: new Date(now - 5400000),
+      });
+      const current = await seedPost(category.id, {
+        title: "Current Post",
+        status: "published",
+        visibility: "public",
+        publishedAt: new Date(now - 3600000),
+      });
+      await seedPost(category.id, {
+        title: "Draft Future",
+        status: "draft",
+        visibility: "public",
+        publishedAt: new Date(now - 1800000),
+      });
+      const publicFuture = await seedPost(category.id, {
+        title: "Public Future",
+        status: "published",
+        visibility: "public",
+        publishedAt: new Date(now),
+      });
+
+      const response = await app.inject({
+        method: "GET",
+        url: `/posts/${current.slug}`,
+      });
+
+      expect(response.statusCode).toBe(200);
+      expect(response.json().prevPost.slug).toBe(publicPast.slug);
+      expect(response.json().nextPost.slug).toBe(publicFuture.slug);
     });
 
     it("존재하지 않는 slug → 404", async () => {
@@ -1396,6 +1503,32 @@ describe("Post Routes", () => {
       expect(body.slugs).toHaveLength(1);
       expect(body.slugs[0].slug).toBe(published.slug);
       expect(body.slugs[0].updatedAt).toBeDefined();
+    });
+
+    it("searchIndexable=false 공개 글은 slug 목록에서 제외된다", async () => {
+      const category = await seedCategory();
+      const visible = await seedPost(category.id, {
+        slug: "indexable-slug",
+        status: "published",
+        visibility: "public",
+        searchIndexable: true,
+      });
+      const noindex = await seedPost(category.id, {
+        slug: "noindex-slug",
+        status: "published",
+        visibility: "public",
+        searchIndexable: false,
+      });
+
+      const response = await app.inject({
+        method: "GET",
+        url: "/posts/slugs",
+      });
+
+      expect(response.statusCode).toBe(200);
+      const slugs = response.json().slugs.map((item: { slug: string }) => item.slug);
+      expect(slugs).toContain(visible.slug);
+      expect(slugs).not.toContain(noindex.slug);
     });
 
     it("발행된 글이 없으면 빈 배열 반환", async () => {

--- a/test/routes/seo.test.ts
+++ b/test/routes/seo.test.ts
@@ -75,6 +75,20 @@ describe("SEO Routes", () => {
       expect(response.body).not.toContain(`/posts/${post.slug}`);
     });
 
+    it("searchIndexable=false 공개 글은 포함되지 않는다", async () => {
+      const category = await seedCategory();
+      const post = await seedPost(category.id, {
+        slug: "noindex-post",
+        status: "published",
+        visibility: "public",
+        searchIndexable: false,
+      });
+
+      const response = await app.inject({ method: "GET", url: "/sitemap.xml" });
+
+      expect(response.body).not.toContain(`/posts/${post.slug}`);
+    });
+
     it("유효한 XML 구조를 반환한다", async () => {
       const response = await app.inject({ method: "GET", url: "/sitemap.xml" });
 
@@ -145,6 +159,23 @@ describe("SEO Routes", () => {
       const response = await app.inject({ method: "GET", url: "/rss.xml" });
 
       expect(response.body).not.toContain(`/posts/${post.slug}`);
+    });
+
+    it("searchIndexable=false 공개 글도 피드에 포함된다", async () => {
+      const category = await seedCategory();
+      const post = await seedPost(category.id, {
+        title: "Noindex RSS Post",
+        slug: "noindex-rss-post",
+        status: "published",
+        visibility: "public",
+        searchIndexable: false,
+      });
+
+      const response = await app.inject({ method: "GET", url: "/rss.xml" });
+
+      expect(response.statusCode).toBe(200);
+      expect(response.body).toContain(post.title);
+      expect(response.body).toContain(`/posts/${post.slug}`);
     });
 
     it("RSS 2.0 구조를 반환한다", async () => {

--- a/test/routes/stats.test.ts
+++ b/test/routes/stats.test.ts
@@ -109,6 +109,26 @@ describe("Stats Routes", () => {
       expect(response.statusCode).toBe(404);
     });
 
+    it("searchIndexable=false 공개 게시글 postId → 200", async () => {
+      const category = await seedCategory();
+      const post = await seedPost(category.id, {
+        status: "published",
+        visibility: "public",
+        searchIndexable: false,
+      });
+      const csrfHeaders = await getCsrfHeaders();
+
+      const response = await app.inject({
+        method: "POST",
+        url: "/stats/view",
+        headers: csrfHeaders,
+        remoteAddress: "10.0.0.40",
+        payload: { postId: post.id },
+      });
+
+      expect(response.statusCode).toBe(200);
+    });
+
     it("같은 IP 5분 내 동일 대상 재요청 → deduplicated: true", async () => {
       const category = await seedCategory();
       const post = await seedPost(category.id, {
@@ -228,6 +248,30 @@ describe("Stats Routes", () => {
 
       expect(response.statusCode).toBe(200);
       expect(response.json().data).toHaveLength(0);
+    });
+
+    it("searchIndexable=false 공개 글은 인기글에 포함된다", async () => {
+      const category = await seedCategory();
+      const post = await seedPost(category.id, {
+        title: "Noindex Popular",
+        status: "published",
+        visibility: "public",
+        searchIndexable: false,
+      });
+
+      const today = new Date();
+      await db
+        .insert(statsDailyTable)
+        .values({ postId: post.id, date: today, pageviews: 100, uniques: 50 });
+
+      const response = await app.inject({
+        method: "GET",
+        url: "/stats/popular",
+      });
+
+      expect(response.statusCode).toBe(200);
+      expect(response.json().data).toHaveLength(1);
+      expect(response.json().data[0].postId).toBe(post.id);
     });
 
     it("limit 파라미터 동작", async () => {


### PR DESCRIPTION
## Summary

Closes #123

Post public access and search-engine indexing are now separate. Public routes only expose published, public, non-deleted posts, while sitemap/slugs additionally require `searchIndexable=true`.

## Changes

| File | Change |
|------|--------|
| `drizzle/0011_post_search_indexable.sql`, `src/db/schema/posts.ts` | Add `search_indexable` with default `true`. |
| `src/routes/posts/*` | Add request/response `searchIndexable`, shared public-readable/search-indexable predicates, and strict public slug/navigation filtering. |
| `src/routes/seo/seo.route.ts` | Use search-indexable posts for sitemap and public-readable posts for RSS. |
| `src/routes/comments/*`, `src/services/stats.service.ts` | Block private/draft/archived post IDs from public comments and view/popular targets while keeping noindex public posts eligible. |
| `test/routes/*.test.ts` | Cover private public-route 404s, noindex list/detail/RSS inclusion, sitemap/slugs exclusion, comments, and stats behavior. |
