### PR TITLE
fix: add admin post deleted state filter (#122)

### DIFF
--- a/api-spec.md
+++ b/api-spec.md
@@ -8,18 +8,19 @@ Auth: `requireAdmin`
 
 Query Parameters:
 
-| Param          | Type    | Default      | Description                            |
-|----------------|---------|--------------|----------------------------------------|
-| page           | number  | 1            | 페이지 번호                             |
-| limit          | number  | 20           | 페이지당 개수 (max 100)                 |
-| status         | string  | -            | `draft` \| `published` \| `archived`   |
-| visibility     | string  | -            | `public` \| `private`                  |
-| categoryId     | number  | -            | 카테고리 필터                            |
-| tagSlug        | string  | -            | 태그 slug 필터                          |
-| q              | string  | -            | 키워드 검색 (title, contentMd)          |
-| includeDeleted | boolean | false        | 소프트 삭제된 글 포함 여부                |
-| sort           | string  | created_at   | 정렬 기준 (`created_at` \| `published_at`) |
-| order          | string  | desc         | 정렬 방향 (`asc` \| `desc`)             |
+| Param          | Type    | Default    | Description                                   |
+| -------------- | ------- | ---------- | --------------------------------------------- |
+| page           | number  | 1          | 페이지 번호                                   |
+| limit          | number  | 20         | 페이지당 개수 (max 100)                       |
+| status         | string  | -          | `draft` \| `published` \| `archived`          |
+| visibility     | string  | -          | `public` \| `private`                         |
+| categoryId     | number  | -          | 카테고리 필터                                 |
+| tagSlug        | string  | -          | 태그 slug 필터                                |
+| q              | string  | -          | 키워드 검색 (title, contentMd)                |
+| deletedState   | string  | active     | 삭제 상태 (`active` \| `deleted` \| `all`)    |
+| includeDeleted | boolean | false      | 하위 호환용 전체 조회 플래그 (`true` = `all`) |
+| sort           | string  | created_at | 정렬 기준 (`created_at` \| `published_at`)    |
+| order          | string  | desc       | 정렬 방향 (`asc` \| `desc`)                   |
 
 Response `200`:
 

--- a/src/routes/posts/post.route.ts
+++ b/src/routes/posts/post.route.ts
@@ -161,7 +161,7 @@ export function createAdminPostRoute(
           tags: ["posts", "admin"],
           summary: "Get all posts (Admin)",
           description:
-            "모든 게시글 목록을 조회합니다. status, visibility, deleted 상태와 무관하게 조회 가능합니다.",
+            "관리자 게시글 목록을 조회합니다. deletedState=active|deleted|all로 삭제 상태를 명시해 필터링할 수 있습니다.",
           security: [{ cookieAuth: [] }],
           querystring: AdminPostListQuerySchema,
           response: {

--- a/src/routes/posts/post.schema.ts
+++ b/src/routes/posts/post.schema.ts
@@ -142,7 +142,14 @@ export const AdminPostListQuerySchema = z.object({
     .describe("정렬 방향"),
   includeDeleted: BooleanQueryParam.optional()
     .default(false)
-    .describe("삭제된 게시글 포함 여부"),
+    .describe("삭제된 게시글 포함 여부 (하위 호환: true면 전체 조회)"),
+  deletedState: z
+    .enum(["active", "deleted", "all"])
+    .optional()
+    .default("active")
+    .describe(
+      "삭제 상태 필터: active=삭제되지 않은 글, deleted=삭제된 글, all=전체",
+    ),
 });
 
 /**

--- a/src/routes/posts/post.schema.ts
+++ b/src/routes/posts/post.schema.ts
@@ -146,7 +146,6 @@ export const AdminPostListQuerySchema = z.object({
   deletedState: z
     .enum(["active", "deleted", "all"])
     .optional()
-    .default("active")
     .describe(
       "삭제 상태 필터: active=삭제되지 않은 글, deleted=삭제된 글, all=전체",
     ),

--- a/src/routes/posts/post.service.ts
+++ b/src/routes/posts/post.service.ts
@@ -11,6 +11,7 @@ import {
   asc,
   like,
   or,
+  isNotNull,
 } from "drizzle-orm";
 import { MySql2Database } from "drizzle-orm/mysql2";
 import type { PoolConnection, RowDataPacket } from "mysql2/promise";
@@ -147,6 +148,7 @@ export interface GetPostListQuery {
   sort?: "published_at" | "created_at" | "totalPageviews" | "commentCount";
   order?: "asc" | "desc";
   includeDeleted?: boolean;
+  deletedState?: "active" | "deleted" | "all";
 }
 
 /**
@@ -446,8 +448,11 @@ export class PostService {
     // WHERE 조건 동적 조합
     const conditions = [];
 
-    // 기본: deleted_at IS NULL
-    if (!query.includeDeleted) {
+    const deletedState = query.deletedState ?? "active";
+
+    if (deletedState === "deleted") {
+      conditions.push(isNotNull(postTable.deletedAt));
+    } else if (deletedState === "active" && !query.includeDeleted) {
       conditions.push(isNull(postTable.deletedAt));
     }
 

--- a/src/routes/posts/post.service.ts
+++ b/src/routes/posts/post.service.ts
@@ -448,11 +448,12 @@ export class PostService {
     // WHERE 조건 동적 조합
     const conditions = [];
 
-    const deletedState = query.deletedState ?? "active";
+    const deletedState =
+      query.deletedState ?? (query.includeDeleted ? "all" : "active");
 
     if (deletedState === "deleted") {
       conditions.push(isNotNull(postTable.deletedAt));
-    } else if (deletedState === "active" && !query.includeDeleted) {
+    } else if (deletedState === "active") {
       conditions.push(isNull(postTable.deletedAt));
     }
 

--- a/test/routes/posts.test.ts
+++ b/test/routes/posts.test.ts
@@ -1182,6 +1182,38 @@ describe("Post Routes", () => {
       );
     });
 
+    it("deletedState=active가 있으면 includeDeleted=true보다 우선한다", async () => {
+      await seedAdmin();
+      const cookie = await injectAuth(app);
+      const category = await seedCategory();
+
+      const activePost = await seedPost(category.id);
+      const deletedPost = await seedPost(category.id);
+
+      await app.inject({
+        method: "DELETE",
+        url: `/admin/posts/${deletedPost.id}`,
+        headers: { cookie },
+      });
+
+      const response = await app.inject({
+        method: "GET",
+        url: "/admin/posts?deletedState=active&includeDeleted=true",
+        headers: { cookie },
+      });
+
+      expect(response.statusCode).toBe(200);
+      const data = response.json().data as {
+        id: number;
+        deletedAt: string | null;
+      }[];
+
+      expect(data).toHaveLength(1);
+      expect(data[0].id).toBe(activePost.id);
+      expect(data[0].id).not.toBe(deletedPost.id);
+      expect(data[0].deletedAt).toBeNull();
+    });
+
     it("includeDeleted=true + category 삭제(trash)된 글도 200으로 반환", async () => {
       await seedAdmin();
       const cookie = await injectAuth(app);

--- a/test/routes/posts.test.ts
+++ b/test/routes/posts.test.ts
@@ -186,13 +186,21 @@ describe("Post Routes", () => {
         method: "POST",
         url: "/admin/posts",
         headers: { cookie },
-        payload: { title: "Duplicate Title", contentMd: "# A", categoryId: category.id },
+        payload: {
+          title: "Duplicate Title",
+          contentMd: "# A",
+          categoryId: category.id,
+        },
       });
       const second = await app.inject({
         method: "POST",
         url: "/admin/posts",
         headers: { cookie },
-        payload: { title: "Duplicate Title", contentMd: "# B", categoryId: category.id },
+        payload: {
+          title: "Duplicate Title",
+          contentMd: "# B",
+          categoryId: category.id,
+        },
       });
 
       expect(first.statusCode).toBe(201);
@@ -650,7 +658,9 @@ describe("Post Routes", () => {
 
       const body = response.json();
       expect(body.post.title).toBe("Updated Title");
-      expect(body.post.thumbnailUrl).toBe("https://cdn.example.com/updated.jpg");
+      expect(body.post.thumbnailUrl).toBe(
+        "https://cdn.example.com/updated.jpg",
+      );
       expect(body.post.tags).toHaveLength(1);
       expect(body.post.tags[0].name).toBe("updated-tag");
     });
@@ -900,7 +910,11 @@ describe("Post Routes", () => {
       await seedAdmin();
       const cookie = await injectAuth(app);
       const parent = await seedCategory({ name: "Parent", slug: "parent-cat" });
-      const child = await seedCategory({ name: "Child", slug: "child-cat", parentId: parent.id });
+      const child = await seedCategory({
+        name: "Child",
+        slug: "child-cat",
+        parentId: parent.id,
+      });
       const post = await seedPost(child.id);
 
       const response = await app.inject({
@@ -1106,6 +1120,68 @@ describe("Post Routes", () => {
       expect(withDeleted.json().data).toHaveLength(1);
     });
 
+    it("deletedState=deleted → 삭제된 글만 반환", async () => {
+      await seedAdmin();
+      const cookie = await injectAuth(app);
+      const category = await seedCategory();
+
+      const activePost = await seedPost(category.id);
+      const deletedPost = await seedPost(category.id);
+
+      await app.inject({
+        method: "DELETE",
+        url: `/admin/posts/${deletedPost.id}`,
+        headers: { cookie },
+      });
+
+      const response = await app.inject({
+        method: "GET",
+        url: "/admin/posts?deletedState=deleted",
+        headers: { cookie },
+      });
+
+      expect(response.statusCode).toBe(200);
+      const data = response.json().data as {
+        id: number;
+        deletedAt: string | null;
+      }[];
+
+      expect(data).toHaveLength(1);
+      expect(data[0].id).toBe(deletedPost.id);
+      expect(data[0].id).not.toBe(activePost.id);
+      expect(data[0].deletedAt).not.toBeNull();
+    });
+
+    it("deletedState=all → 삭제되지 않은 글과 삭제된 글을 함께 반환", async () => {
+      await seedAdmin();
+      const cookie = await injectAuth(app);
+      const category = await seedCategory();
+
+      const activePost = await seedPost(category.id);
+      const deletedPost = await seedPost(category.id);
+
+      await app.inject({
+        method: "DELETE",
+        url: `/admin/posts/${deletedPost.id}`,
+        headers: { cookie },
+      });
+
+      const response = await app.inject({
+        method: "GET",
+        url: "/admin/posts?deletedState=all",
+        headers: { cookie },
+      });
+
+      expect(response.statusCode).toBe(200);
+      const ids = (response.json().data as { id: number }[]).map(
+        (post) => post.id,
+      );
+
+      expect(ids).toEqual(
+        expect.arrayContaining([activePost.id, deletedPost.id]),
+      );
+    });
+
     it("includeDeleted=true + category 삭제(trash)된 글도 200으로 반환", async () => {
       await seedAdmin();
       const cookie = await injectAuth(app);
@@ -1189,15 +1265,41 @@ describe("Post Routes", () => {
       const cookie = await injectAuth(app);
       const category = await seedCategory();
 
-      const lowViewsPost = await seedPost(category.id, { title: "Low Views Post" });
-      const highViewsPost = await seedPost(category.id, { title: "High Views Post" });
-      const midViewsPost = await seedPost(category.id, { title: "Mid Views Post" });
+      const lowViewsPost = await seedPost(category.id, {
+        title: "Low Views Post",
+      });
+      const highViewsPost = await seedPost(category.id, {
+        title: "High Views Post",
+      });
+      const midViewsPost = await seedPost(category.id, {
+        title: "Mid Views Post",
+      });
 
       await db.insert(statsDailyTable).values([
-        { postId: lowViewsPost.id, date: new Date("2026-03-01"), pageviews: 5, uniques: 3 },
-        { postId: highViewsPost.id, date: new Date("2026-03-01"), pageviews: 20, uniques: 10 },
-        { postId: highViewsPost.id, date: new Date("2026-03-02"), pageviews: 3, uniques: 2 },
-        { postId: midViewsPost.id, date: new Date("2026-03-01"), pageviews: 11, uniques: 5 },
+        {
+          postId: lowViewsPost.id,
+          date: new Date("2026-03-01"),
+          pageviews: 5,
+          uniques: 3,
+        },
+        {
+          postId: highViewsPost.id,
+          date: new Date("2026-03-01"),
+          pageviews: 20,
+          uniques: 10,
+        },
+        {
+          postId: highViewsPost.id,
+          date: new Date("2026-03-02"),
+          pageviews: 3,
+          uniques: 2,
+        },
+        {
+          postId: midViewsPost.id,
+          date: new Date("2026-03-01"),
+          pageviews: 11,
+          uniques: 5,
+        },
       ]);
 
       const response = await app.inject({
@@ -1214,7 +1316,11 @@ describe("Post Routes", () => {
         "Mid Views Post",
         "Low Views Post",
       ]);
-      expect(body.data.map((post: { totalPageviews: number }) => post.totalPageviews)).toEqual([23, 11, 5]);
+      expect(
+        body.data.map(
+          (post: { totalPageviews: number }) => post.totalPageviews,
+        ),
+      ).toEqual([23, 11, 5]);
     });
 
     it("sort=totalPageviews&order=asc → 조회수 합계 낮은 순으로 반환", async () => {
@@ -1222,13 +1328,29 @@ describe("Post Routes", () => {
       const cookie = await injectAuth(app);
       const category = await seedCategory();
 
-      const zeroViewsPost = await seedPost(category.id, { title: "Zero Views Post" });
-      const lowViewsPost = await seedPost(category.id, { title: "Low Views Post" });
-      const highViewsPost = await seedPost(category.id, { title: "High Views Post" });
+      const zeroViewsPost = await seedPost(category.id, {
+        title: "Zero Views Post",
+      });
+      const lowViewsPost = await seedPost(category.id, {
+        title: "Low Views Post",
+      });
+      const highViewsPost = await seedPost(category.id, {
+        title: "High Views Post",
+      });
 
       await db.insert(statsDailyTable).values([
-        { postId: lowViewsPost.id, date: new Date("2026-03-03"), pageviews: 2, uniques: 1 },
-        { postId: highViewsPost.id, date: new Date("2026-03-03"), pageviews: 9, uniques: 4 },
+        {
+          postId: lowViewsPost.id,
+          date: new Date("2026-03-03"),
+          pageviews: 2,
+          uniques: 1,
+        },
+        {
+          postId: highViewsPost.id,
+          date: new Date("2026-03-03"),
+          pageviews: 9,
+          uniques: 4,
+        },
       ]);
 
       const response = await app.inject({
@@ -1245,7 +1367,11 @@ describe("Post Routes", () => {
         "Low Views Post",
         "High Views Post",
       ]);
-      expect(body.data.map((post: { totalPageviews: number }) => post.totalPageviews)).toEqual([0, 2, 9]);
+      expect(
+        body.data.map(
+          (post: { totalPageviews: number }) => post.totalPageviews,
+        ),
+      ).toEqual([0, 2, 9]);
     });
 
     it("sort=commentCount&order=desc → 댓글 수 높은 순으로 반환", async () => {
@@ -1253,9 +1379,15 @@ describe("Post Routes", () => {
       const cookie = await injectAuth(app);
       const category = await seedCategory();
 
-      const noCommentPost = await seedPost(category.id, { title: "No Comment Post" });
-      const oneCommentPost = await seedPost(category.id, { title: "One Comment Post" });
-      const threeCommentPost = await seedPost(category.id, { title: "Three Comment Post" });
+      const noCommentPost = await seedPost(category.id, {
+        title: "No Comment Post",
+      });
+      const oneCommentPost = await seedPost(category.id, {
+        title: "One Comment Post",
+      });
+      const threeCommentPost = await seedPost(category.id, {
+        title: "Three Comment Post",
+      });
 
       await seedComment(oneCommentPost.id);
       await seedComment(threeCommentPost.id);
@@ -1276,7 +1408,9 @@ describe("Post Routes", () => {
         "One Comment Post",
         "No Comment Post",
       ]);
-      expect(body.data.map((post: { commentCount: number }) => post.commentCount)).toEqual([3, 1, 0]);
+      expect(
+        body.data.map((post: { commentCount: number }) => post.commentCount),
+      ).toEqual([3, 1, 0]);
     });
 
     it("sort=commentCount&order=asc → 필터/페이지네이션과 함께 댓글 수 낮은 순으로 반환", async () => {
@@ -1458,7 +1592,10 @@ describe("Post Routes", () => {
 
     it("filter=tag, 매칭 태그 없음 → 빈 배열", async () => {
       const category = await seedCategory();
-      await seedPost(category.id, { status: "published", visibility: "public" });
+      await seedPost(category.id, {
+        status: "published",
+        visibility: "public",
+      });
 
       const response = await app.inject({
         method: "GET",
@@ -1474,7 +1611,10 @@ describe("Post Routes", () => {
       const frontend = await seedCategory({ name: "Frontend Development" });
 
       await seedPost(backend.id, { status: "published", visibility: "public" });
-      await seedPost(frontend.id, { status: "published", visibility: "public" });
+      await seedPost(frontend.id, {
+        status: "published",
+        visibility: "public",
+      });
 
       const response = await app.inject({
         method: "GET",
@@ -1489,7 +1629,10 @@ describe("Post Routes", () => {
 
     it("filter=category, 매칭 카테고리 없음 → 빈 배열", async () => {
       const category = await seedCategory({ name: "Existing Category" });
-      await seedPost(category.id, { status: "published", visibility: "public" });
+      await seedPost(category.id, {
+        status: "published",
+        visibility: "public",
+      });
 
       const response = await app.inject({
         method: "GET",
@@ -1549,7 +1692,10 @@ describe("Post Routes", () => {
 
     it("filter=comment, 매칭 댓글 없음 → 빈 배열", async () => {
       const category = await seedCategory();
-      await seedPost(category.id, { status: "published", visibility: "public" });
+      await seedPost(category.id, {
+        status: "published",
+        visibility: "public",
+      });
 
       const response = await app.inject({
         method: "GET",
@@ -1627,7 +1773,10 @@ describe("Post Routes", () => {
       const cookie = await injectAuth(app);
 
       const parent = await seedCategory({ name: "Programming" });
-      const child = await seedCategory({ name: "TypeScript", parentId: parent.id });
+      const child = await seedCategory({
+        name: "TypeScript",
+        parentId: parent.id,
+      });
 
       const createRes = await app.inject({
         method: "POST",
@@ -1946,7 +2095,11 @@ describe("Post Routes", () => {
         method: "PATCH",
         url: "/admin/posts/bulk",
         headers: { cookie },
-        payload: { ids: [post1.id, post2.id], action: "update", categoryId: cat2.id },
+        payload: {
+          ids: [post1.id, post2.id],
+          action: "update",
+          categoryId: cat2.id,
+        },
       });
 
       expect(response.statusCode).toBe(204);
@@ -1971,7 +2124,11 @@ describe("Post Routes", () => {
         method: "PATCH",
         url: "/admin/posts/bulk",
         headers: { cookie },
-        payload: { ids: [post1.id, post2.id], action: "update", commentStatus: "locked" },
+        payload: {
+          ids: [post1.id, post2.id],
+          action: "update",
+          commentStatus: "locked",
+        },
       });
 
       expect(response.statusCode).toBe(204);
@@ -2302,5 +2459,4 @@ describe("Post Routes", () => {
       expect(response.statusCode).toBe(403);
     });
   });
-
 });


### PR DESCRIPTION
## Summary

Closes #122

Adds an explicit admin post deleted-state filter so the trash view can request deleted posts only while preserving legacy includeDeleted behavior.

## Changes

| File | Change |
|------|--------|
| `src/routes/posts/post.schema.ts` | Added `deletedState=active|deleted|all` to admin post list query schema and clarified legacy `includeDeleted`. |
| `src/routes/posts/post.service.ts` | Applies `deleted_at IS NOT NULL` for `deletedState=deleted`, keeps default active filtering, and keeps `includeDeleted=true` as all-posts compatibility. |
| `src/routes/posts/post.route.ts` | Updated admin list OpenAPI description for the explicit deleted-state filter. |
| `test/routes/posts.test.ts` | Added regressions for `deletedState=deleted` and `deletedState=all`; retained `includeDeleted=false` regression. |
| `api-spec.md` | Documented `deletedState` and legacy `includeDeleted` behavior. |

## Screenshots

N/A - API/server change.
