### PR TITLE
feat: add asset metadata categories (#124)

### DIFF
--- a/drizzle/0012_asset_categories.sql
+++ b/drizzle/0012_asset_categories.sql
@@ -1,0 +1,29 @@
+CREATE TABLE `asset_category_tb` (
+	`id` int AUTO_INCREMENT NOT NULL,
+	`key` varchar(50),
+	`name` varchar(50) NOT NULL,
+	`sort_order` int NOT NULL DEFAULT 0,
+	`is_protected` boolean NOT NULL DEFAULT false,
+	`created_at` timestamp NOT NULL DEFAULT (now()),
+	`updated_at` timestamp NOT NULL DEFAULT (now()) ON UPDATE CURRENT_TIMESTAMP,
+	CONSTRAINT `asset_category_tb_id` PRIMARY KEY(`id`)
+);
+--> statement-breakpoint
+CREATE UNIQUE INDEX `asset_category_key_idx` ON `asset_category_tb` (`key`);--> statement-breakpoint
+CREATE INDEX `asset_category_sort_order_idx` ON `asset_category_tb` (`sort_order`);--> statement-breakpoint
+INSERT IGNORE INTO `asset_category_tb` (`key`, `name`, `sort_order`, `is_protected`) VALUES
+	('thumbnail', '썸네일', 0, true),
+	('default', '기본', 1, true),
+	('uncategorized', '미분류', 2, true);
+--> statement-breakpoint
+ALTER TABLE `asset_tb` ADD `category_id` int;--> statement-breakpoint
+ALTER TABLE `asset_tb` ADD `display_name` varchar(200);--> statement-breakpoint
+UPDATE `asset_tb`
+SET `category_id` = (
+	SELECT `id` FROM `asset_category_tb` WHERE `key` = 'uncategorized' LIMIT 1
+)
+WHERE `category_id` IS NULL;
+--> statement-breakpoint
+ALTER TABLE `asset_tb` MODIFY COLUMN `category_id` int NOT NULL;--> statement-breakpoint
+CREATE INDEX `asset_category_id_idx` ON `asset_tb` (`category_id`);--> statement-breakpoint
+CREATE INDEX `asset_display_name_idx` ON `asset_tb` (`display_name`);

--- a/drizzle/meta/0012_snapshot.json
+++ b/drizzle/meta/0012_snapshot.json
@@ -1,0 +1,1153 @@
+{
+  "version": "5",
+  "dialect": "mysql",
+  "id": "6d2e0400-b866-4507-94c5-9aa35fed1e47",
+  "prevId": "b1e516ca-2812-43c3-97a7-37a51828a7e6",
+  "tables": {
+    "session_tb": {
+      "name": "session_tb",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "varchar(128)",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "expires_at": {
+          "name": "expires_at",
+          "type": "int",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "data": {
+          "name": "data",
+          "type": "varchar(2048)",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {},
+      "compositePrimaryKeys": {
+        "session_tb_id": {
+          "name": "session_tb_id",
+          "columns": [
+            "id"
+          ]
+        }
+      },
+      "uniqueConstraints": {},
+      "checkConstraint": {}
+    },
+    "admin_tb": {
+      "name": "admin_tb",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "int",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": true
+        },
+        "email": {
+          "name": "email",
+          "type": "varchar(100)",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "password_hash": {
+          "name": "password_hash",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "(now())"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "onUpdate": true,
+          "default": "(now())"
+        },
+        "last_login_at": {
+          "name": "last_login_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {},
+      "compositePrimaryKeys": {
+        "admin_tb_id": {
+          "name": "admin_tb_id",
+          "columns": [
+            "id"
+          ]
+        }
+      },
+      "uniqueConstraints": {
+        "admin_tb_email_unique": {
+          "name": "admin_tb_email_unique",
+          "columns": [
+            "email"
+          ]
+        }
+      },
+      "checkConstraint": {}
+    },
+    "oauth_account_tb": {
+      "name": "oauth_account_tb",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "int",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": true
+        },
+        "provider": {
+          "name": "provider",
+          "type": "enum('github','google')",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "provider_user_id": {
+          "name": "provider_user_id",
+          "type": "varchar(100)",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "email": {
+          "name": "email",
+          "type": "varchar(100)",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "display_name": {
+          "name": "display_name",
+          "type": "varchar(100)",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "avatar_url": {
+          "name": "avatar_url",
+          "type": "varchar(500)",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "(now())"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "onUpdate": true,
+          "default": "(now())"
+        },
+        "deleted_at": {
+          "name": "deleted_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        }
+      },
+      "indexes": {
+        "provider_user_idx": {
+          "name": "provider_user_idx",
+          "columns": [
+            "provider",
+            "provider_user_id"
+          ],
+          "isUnique": true
+        }
+      },
+      "foreignKeys": {},
+      "compositePrimaryKeys": {
+        "oauth_account_tb_id": {
+          "name": "oauth_account_tb_id",
+          "columns": [
+            "id"
+          ]
+        }
+      },
+      "uniqueConstraints": {},
+      "checkConstraint": {}
+    },
+    "category_tb": {
+      "name": "category_tb",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "int",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": true
+        },
+        "parent_id": {
+          "name": "parent_id",
+          "type": "int",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "name": {
+          "name": "name",
+          "type": "varchar(50)",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "slug": {
+          "name": "slug",
+          "type": "varchar(100)",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "sort_order": {
+          "name": "sort_order",
+          "type": "int",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": 0
+        },
+        "is_visible": {
+          "name": "is_visible",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": true
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "(now())"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "onUpdate": true,
+          "default": "(now())"
+        }
+      },
+      "indexes": {
+        "parent_id_idx": {
+          "name": "parent_id_idx",
+          "columns": [
+            "parent_id"
+          ],
+          "isUnique": false
+        },
+        "sort_order_idx": {
+          "name": "sort_order_idx",
+          "columns": [
+            "sort_order"
+          ],
+          "isUnique": false
+        }
+      },
+      "foreignKeys": {},
+      "compositePrimaryKeys": {
+        "category_tb_id": {
+          "name": "category_tb_id",
+          "columns": [
+            "id"
+          ]
+        }
+      },
+      "uniqueConstraints": {
+        "category_tb_slug_unique": {
+          "name": "category_tb_slug_unique",
+          "columns": [
+            "slug"
+          ]
+        }
+      },
+      "checkConstraint": {}
+    },
+    "tag_tb": {
+      "name": "tag_tb",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "int",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": true
+        },
+        "name": {
+          "name": "name",
+          "type": "varchar(30)",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "slug": {
+          "name": "slug",
+          "type": "varchar(50)",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "(now())"
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {},
+      "compositePrimaryKeys": {
+        "tag_tb_id": {
+          "name": "tag_tb_id",
+          "columns": [
+            "id"
+          ]
+        }
+      },
+      "uniqueConstraints": {
+        "tag_tb_name_unique": {
+          "name": "tag_tb_name_unique",
+          "columns": [
+            "name"
+          ]
+        },
+        "tag_tb_slug_unique": {
+          "name": "tag_tb_slug_unique",
+          "columns": [
+            "slug"
+          ]
+        }
+      },
+      "checkConstraint": {}
+    },
+    "asset_tb": {
+      "name": "asset_tb",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "int",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": true
+        },
+        "category_id": {
+          "name": "category_id",
+          "type": "int",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "display_name": {
+          "name": "display_name",
+          "type": "varchar(200)",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "storage_provider": {
+          "name": "storage_provider",
+          "type": "varchar(20)",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "'local'"
+        },
+        "storage_key": {
+          "name": "storage_key",
+          "type": "varchar(500)",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "mime_type": {
+          "name": "mime_type",
+          "type": "varchar(100)",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "size_bytes": {
+          "name": "size_bytes",
+          "type": "int",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "width": {
+          "name": "width",
+          "type": "int",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "height": {
+          "name": "height",
+          "type": "int",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "(now())"
+        }
+      },
+      "indexes": {
+        "asset_category_id_idx": {
+          "name": "asset_category_id_idx",
+          "columns": [
+            "category_id"
+          ],
+          "isUnique": false
+        },
+        "asset_display_name_idx": {
+          "name": "asset_display_name_idx",
+          "columns": [
+            "display_name"
+          ],
+          "isUnique": false
+        }
+      },
+      "foreignKeys": {},
+      "compositePrimaryKeys": {
+        "asset_tb_id": {
+          "name": "asset_tb_id",
+          "columns": [
+            "id"
+          ]
+        }
+      },
+      "uniqueConstraints": {},
+      "checkConstraint": {}
+    },
+    "post_tb": {
+      "name": "post_tb",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "int",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": true
+        },
+        "category_id": {
+          "name": "category_id",
+          "type": "int",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "title": {
+          "name": "title",
+          "type": "varchar(200)",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "slug": {
+          "name": "slug",
+          "type": "varchar(200)",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "content_md": {
+          "name": "content_md",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "thumbnail_url": {
+          "name": "thumbnail_url",
+          "type": "varchar(500)",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "visibility": {
+          "name": "visibility",
+          "type": "enum('public','private')",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "'public'"
+        },
+        "search_indexable": {
+          "name": "search_indexable",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "true"
+        },
+        "status": {
+          "name": "status",
+          "type": "enum('draft','published','archived')",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "'draft'"
+        },
+        "published_at": {
+          "name": "published_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "(now())"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "onUpdate": true,
+          "default": "(now())"
+        },
+        "deleted_at": {
+          "name": "deleted_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "summary": {
+          "name": "summary",
+          "type": "varchar(200)",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "description": {
+          "name": "description",
+          "type": "varchar(300)",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "comment_status": {
+          "name": "comment_status",
+          "type": "enum('open','locked','disabled')",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "'open'"
+        },
+        "is_pinned": {
+          "name": "is_pinned",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "false"
+        },
+        "content_modified_at": {
+          "name": "content_modified_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        }
+      },
+      "indexes": {
+        "category_published_idx": {
+          "name": "category_published_idx",
+          "columns": [
+            "category_id",
+            "published_at"
+          ],
+          "isUnique": false
+        },
+        "status_published_idx": {
+          "name": "status_published_idx",
+          "columns": [
+            "status",
+            "published_at"
+          ],
+          "isUnique": false
+        }
+      },
+      "foreignKeys": {},
+      "compositePrimaryKeys": {
+        "post_tb_id": {
+          "name": "post_tb_id",
+          "columns": [
+            "id"
+          ]
+        }
+      },
+      "uniqueConstraints": {
+        "post_tb_slug_unique": {
+          "name": "post_tb_slug_unique",
+          "columns": [
+            "slug"
+          ]
+        }
+      },
+      "checkConstraint": {}
+    },
+    "post_tag_tb": {
+      "name": "post_tag_tb",
+      "columns": {
+        "post_id": {
+          "name": "post_id",
+          "type": "int",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "tag_id": {
+          "name": "tag_id",
+          "type": "int",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        }
+      },
+      "indexes": {
+        "tag_id_idx": {
+          "name": "tag_id_idx",
+          "columns": [
+            "tag_id"
+          ],
+          "isUnique": false
+        }
+      },
+      "foreignKeys": {},
+      "compositePrimaryKeys": {
+        "post_tag_tb_post_id_tag_id_pk": {
+          "name": "post_tag_tb_post_id_tag_id_pk",
+          "columns": [
+            "post_id",
+            "tag_id"
+          ]
+        }
+      },
+      "uniqueConstraints": {},
+      "checkConstraint": {}
+    },
+    "comment_tb": {
+      "name": "comment_tb",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "int",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": true
+        },
+        "post_id": {
+          "name": "post_id",
+          "type": "int",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "parent_id": {
+          "name": "parent_id",
+          "type": "int",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "depth": {
+          "name": "depth",
+          "type": "int",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": 0
+        },
+        "reply_to_comment_id": {
+          "name": "reply_to_comment_id",
+          "type": "int",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "reply_to_name": {
+          "name": "reply_to_name",
+          "type": "varchar(50)",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "author_type": {
+          "name": "author_type",
+          "type": "enum('oauth','guest')",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "oauth_account_id": {
+          "name": "oauth_account_id",
+          "type": "int",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "guest_name": {
+          "name": "guest_name",
+          "type": "varchar(50)",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "guest_email": {
+          "name": "guest_email",
+          "type": "varchar(100)",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "guest_password_hash": {
+          "name": "guest_password_hash",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "body": {
+          "name": "body",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "is_secret": {
+          "name": "is_secret",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": false
+        },
+        "status": {
+          "name": "status",
+          "type": "enum('active','deleted','hidden')",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "'active'"
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "(now())"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "onUpdate": true,
+          "default": "(now())"
+        },
+        "deleted_at": {
+          "name": "deleted_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        }
+      },
+      "indexes": {
+        "post_parent_created_idx": {
+          "name": "post_parent_created_idx",
+          "columns": [
+            "post_id",
+            "parent_id",
+            "created_at"
+          ],
+          "isUnique": false
+        },
+        "oauth_account_idx": {
+          "name": "oauth_account_idx",
+          "columns": [
+            "oauth_account_id"
+          ],
+          "isUnique": false
+        },
+        "status_idx": {
+          "name": "status_idx",
+          "columns": [
+            "status"
+          ],
+          "isUnique": false
+        }
+      },
+      "foreignKeys": {},
+      "compositePrimaryKeys": {
+        "comment_tb_id": {
+          "name": "comment_tb_id",
+          "columns": [
+            "id"
+          ]
+        }
+      },
+      "uniqueConstraints": {},
+      "checkConstraint": {}
+    },
+    "guestbook_entry_tb": {
+      "name": "guestbook_entry_tb",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "int",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": true
+        },
+        "parent_id": {
+          "name": "parent_id",
+          "type": "int",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "author_type": {
+          "name": "author_type",
+          "type": "enum('oauth','guest')",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "oauth_account_id": {
+          "name": "oauth_account_id",
+          "type": "int",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "guest_name": {
+          "name": "guest_name",
+          "type": "varchar(50)",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "guest_email": {
+          "name": "guest_email",
+          "type": "varchar(100)",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "guest_password_hash": {
+          "name": "guest_password_hash",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "body": {
+          "name": "body",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "is_secret": {
+          "name": "is_secret",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": false
+        },
+        "status": {
+          "name": "status",
+          "type": "enum('active','deleted','hidden')",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "'active'"
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "(now())"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "onUpdate": true,
+          "default": "(now())"
+        },
+        "deleted_at": {
+          "name": "deleted_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        }
+      },
+      "indexes": {
+        "parent_id_idx": {
+          "name": "parent_id_idx",
+          "columns": [
+            "parent_id"
+          ],
+          "isUnique": false
+        },
+        "oauth_account_idx": {
+          "name": "oauth_account_idx",
+          "columns": [
+            "oauth_account_id"
+          ],
+          "isUnique": false
+        },
+        "status_idx": {
+          "name": "status_idx",
+          "columns": [
+            "status"
+          ],
+          "isUnique": false
+        }
+      },
+      "foreignKeys": {},
+      "compositePrimaryKeys": {
+        "guestbook_entry_tb_id": {
+          "name": "guestbook_entry_tb_id",
+          "columns": [
+            "id"
+          ]
+        }
+      },
+      "uniqueConstraints": {},
+      "checkConstraint": {}
+    },
+    "stats_daily_tb": {
+      "name": "stats_daily_tb",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "int",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": true
+        },
+        "post_id": {
+          "name": "post_id",
+          "type": "int",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "date": {
+          "name": "date",
+          "type": "date",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "pageviews": {
+          "name": "pageviews",
+          "type": "int",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": 0
+        },
+        "uniques": {
+          "name": "uniques",
+          "type": "int",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": 0
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "(now())"
+        }
+      },
+      "indexes": {
+        "post_date_idx": {
+          "name": "post_date_idx",
+          "columns": [
+            "post_id",
+            "date"
+          ],
+          "isUnique": true
+        }
+      },
+      "foreignKeys": {},
+      "compositePrimaryKeys": {
+        "stats_daily_tb_id": {
+          "name": "stats_daily_tb_id",
+          "columns": [
+            "id"
+          ]
+        }
+      },
+      "uniqueConstraints": {},
+      "checkConstraint": {}
+    },
+    "asset_category_tb": {
+      "name": "asset_category_tb",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "int",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": true
+        },
+        "key": {
+          "name": "key",
+          "type": "varchar(50)",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "name": {
+          "name": "name",
+          "type": "varchar(50)",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "sort_order": {
+          "name": "sort_order",
+          "type": "int",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "0"
+        },
+        "is_protected": {
+          "name": "is_protected",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "false"
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "(now())"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "(now())",
+          "onUpdate": true
+        }
+      },
+      "indexes": {
+        "asset_category_key_idx": {
+          "name": "asset_category_key_idx",
+          "columns": [
+            "key"
+          ],
+          "isUnique": true
+        },
+        "asset_category_sort_order_idx": {
+          "name": "asset_category_sort_order_idx",
+          "columns": [
+            "sort_order"
+          ],
+          "isUnique": false
+        }
+      },
+      "foreignKeys": {},
+      "compositePrimaryKeys": {
+        "asset_category_tb_id": {
+          "name": "asset_category_tb_id",
+          "columns": [
+            "id"
+          ]
+        }
+      },
+      "uniqueConstraints": {},
+      "checkConstraint": {}
+    }
+  },
+  "views": {},
+  "_meta": {
+    "schemas": {},
+    "tables": {},
+    "columns": {}
+  },
+  "internal": {
+    "tables": {},
+    "indexes": {}
+  }
+}

--- a/drizzle/meta/_journal.json
+++ b/drizzle/meta/_journal.json
@@ -85,6 +85,13 @@
       "when": 1777791600000,
       "tag": "0011_post_search_indexable",
       "breakpoints": true
+    },
+    {
+      "idx": 12,
+      "version": "5",
+      "when": 1777791700000,
+      "tag": "0012_asset_categories",
+      "breakpoints": true
     }
   ]
 }

--- a/src/db/schema/assets.ts
+++ b/src/db/schema/assets.ts
@@ -1,24 +1,63 @@
-import { mysqlTable, int, varchar, timestamp } from "drizzle-orm/mysql-core";
+import {
+  boolean,
+  index,
+  int,
+  mysqlTable,
+  timestamp,
+  uniqueIndex,
+  varchar,
+} from "drizzle-orm/mysql-core";
+
+/**
+ * Asset Category Table - 에셋 관리/필터링용 flat 카테고리
+ */
+export const assetCategoryTable = mysqlTable(
+  "asset_category_tb",
+  {
+    id: int("id").primaryKey().autoincrement(),
+    key: varchar("key", { length: 50 }),
+    name: varchar("name", { length: 50 }).notNull(),
+    sortOrder: int("sort_order").default(0).notNull(),
+    isProtected: boolean("is_protected").default(false).notNull(),
+    createdAt: timestamp("created_at").defaultNow().notNull(),
+    updatedAt: timestamp("updated_at").defaultNow().onUpdateNow().notNull(),
+  },
+  (table) => ({
+    keyIdx: uniqueIndex("asset_category_key_idx").on(table.key),
+    sortOrderIdx: index("asset_category_sort_order_idx").on(table.sortOrder),
+  }),
+);
 
 /**
  * Asset Table - 이미지/파일 자산
  * 기존 imageTable을 대체하는 확장된 자산 관리 테이블
  */
-export const assetTable = mysqlTable("asset_tb", {
-  id: int("id").primaryKey().autoincrement(),
-  storageProvider: varchar("storage_provider", { length: 20 })
-    .default("local")
-    .notNull(),
-  storageKey: varchar("storage_key", { length: 500 }).notNull(),
-  mimeType: varchar("mime_type", { length: 100 }).notNull(),
-  sizeBytes: int("size_bytes").notNull(),
-  width: int("width"),
-  height: int("height"),
-  createdAt: timestamp("created_at").defaultNow().notNull(),
-});
+export const assetTable = mysqlTable(
+  "asset_tb",
+  {
+    id: int("id").primaryKey().autoincrement(),
+    categoryId: int("category_id").notNull(),
+    displayName: varchar("display_name", { length: 200 }),
+    storageProvider: varchar("storage_provider", { length: 20 })
+      .default("local")
+      .notNull(),
+    storageKey: varchar("storage_key", { length: 500 }).notNull(),
+    mimeType: varchar("mime_type", { length: 100 }).notNull(),
+    sizeBytes: int("size_bytes").notNull(),
+    width: int("width"),
+    height: int("height"),
+    createdAt: timestamp("created_at").defaultNow().notNull(),
+  },
+  (table) => ({
+    categoryIdIdx: index("asset_category_id_idx").on(table.categoryId),
+    displayNameIdx: index("asset_display_name_idx").on(table.displayName),
+  }),
+);
 
 /**
  * Types
  */
 export type Asset = typeof assetTable.$inferSelect;
 export type NewAsset = typeof assetTable.$inferInsert;
+export type AssetCategory = typeof assetCategoryTable.$inferSelect;
+export type NewAssetCategory = typeof assetCategoryTable.$inferInsert;

--- a/src/routes/assets/asset.route.ts
+++ b/src/routes/assets/asset.route.ts
@@ -2,19 +2,129 @@ import { FastifyPluginAsync, FastifyInstance } from "fastify";
 import { ZodTypeProvider } from "fastify-type-provider-zod";
 import { z } from "zod";
 import {
+  assetCategoryIdParamSchema,
+  assetCategoryListResponseSchema,
+  assetCategoryResponseSchema,
   assetIdParamSchema,
   assetListQuerySchema,
   assetListResponseSchema,
   uploadAssetsResponseSchema,
   assetResponseSchema,
+  bulkUpdateAssetCategoryBodySchema,
+  createAssetCategoryBodySchema,
   bulkDeleteAssetsBodySchema,
   errorResponseSchema,
+  updateAssetBodySchema,
+  updateAssetCategoryBodySchema,
 } from "./asset.schema";
-import { AssetService } from "./asset.service";
+import { AssetService, type AssetUploadMetadata } from "./asset.service";
 import { HttpError } from "@src/errors/http-error";
 import { requireAdmin } from "@src/hooks/auth.hook";
 import { AdminService } from "@src/routes/auth/admin.service";
 import { FileStorageService } from "@src/services/file-storage.service";
+
+type MultipartFieldMap = Map<string, string[]>;
+
+function appendMultipartField(
+  fields: MultipartFieldMap,
+  name: string,
+  value: unknown,
+): void {
+  if (typeof value !== "string" && typeof value !== "number") {
+    return;
+  }
+
+  const values = fields.get(name) ?? [];
+  values.push(String(value));
+  fields.set(name, values);
+}
+
+function parsePositiveInteger(value: string, fieldName: string): number {
+  const parsed = Number(value);
+
+  if (!Number.isInteger(parsed) || parsed <= 0) {
+    throw HttpError.badRequest(`${fieldName} must be a positive integer.`);
+  }
+
+  return parsed;
+}
+
+function parseMetadataJson(value: string): AssetUploadMetadata[] {
+  let parsed: unknown;
+
+  try {
+    parsed = JSON.parse(value);
+  } catch {
+    throw HttpError.badRequest("metadata must be valid JSON.");
+  }
+
+  const entries = Array.isArray(parsed) ? parsed : [parsed];
+
+  return entries.map((entry) => {
+    if (typeof entry !== "object" || entry === null) {
+      throw HttpError.badRequest("metadata entries must be objects.");
+    }
+
+    const source = entry as Record<string, unknown>;
+    const metadata: AssetUploadMetadata = {};
+
+    if (source.displayName !== undefined && source.displayName !== null) {
+      if (typeof source.displayName !== "string") {
+        throw HttpError.badRequest("metadata.displayName must be a string.");
+      }
+      metadata.displayName = source.displayName;
+    }
+
+    if (source.categoryId !== undefined) {
+      if (
+        typeof source.categoryId !== "number" ||
+        !Number.isInteger(source.categoryId) ||
+        source.categoryId <= 0
+      ) {
+        throw HttpError.badRequest(
+          "metadata.categoryId must be a positive integer.",
+        );
+      }
+      metadata.categoryId = source.categoryId;
+    }
+
+    return metadata;
+  });
+}
+
+function buildUploadMetadata(
+  fields: MultipartFieldMap,
+  fileCount: number,
+): AssetUploadMetadata[] {
+  const metadata: AssetUploadMetadata[] = Array.from(
+    { length: fileCount },
+    () => ({}),
+  );
+  const metadataField = fields.get("metadata")?.[0];
+
+  if (metadataField) {
+    const parsedMetadata = parseMetadataJson(metadataField);
+    if (parsedMetadata.length > fileCount) {
+      throw HttpError.badRequest("metadata contains more entries than files.");
+    }
+
+    parsedMetadata.forEach((entry, index) => {
+      metadata[index] = { ...metadata[index], ...entry };
+    });
+  }
+
+  const displayNames = fields.get("displayName") ?? [];
+  displayNames.slice(0, fileCount).forEach((displayName, index) => {
+    metadata[index].displayName = displayName;
+  });
+
+  const categoryIds = fields.get("categoryId") ?? [];
+  categoryIds.slice(0, fileCount).forEach((categoryId, index) => {
+    metadata[index].categoryId = parsePositiveInteger(categoryId, "categoryId");
+  });
+
+  return metadata;
+}
 
 /**
  * Asset 라우트 플러그인
@@ -59,9 +169,14 @@ export function createAssetRoute(
         // 파일 수신 및 버퍼링
         // multipart 스트림은 iterator 루프 내에서 즉시 소비해야 hang을 방지할 수 있음
         const bufferedFiles = [];
+        const fields: MultipartFieldMap = new Map();
 
-        for await (const file of request.files()) {
-          bufferedFiles.push(await FileStorageService.bufferFile(file));
+        for await (const part of request.parts()) {
+          if (part.type === "file") {
+            bufferedFiles.push(await FileStorageService.bufferFile(part));
+          } else {
+            appendMultipartField(fields, part.fieldname, part.value);
+          }
         }
 
         if (bufferedFiles.length === 0) {
@@ -69,7 +184,10 @@ export function createAssetRoute(
         }
 
         // 파일 업로드 처리
-        const assets = await assetService.uploadAssets(bufferedFiles);
+        const assets = await assetService.uploadAssets(
+          bufferedFiles,
+          buildUploadMetadata(fields, bufferedFiles.length),
+        );
 
         return reply.status(201).send({
           assets,
@@ -103,6 +221,120 @@ export function createAssetRoute(
       },
     );
 
+    // GET /assets/categories - Asset 카테고리 목록 조회 (Admin)
+    typedFastify.get(
+      "/categories",
+      {
+        preHandler: requireAdmin(adminService),
+        schema: {
+          tags: ["assets"],
+          summary: "Get asset categories",
+          description:
+            "에셋 카테고리 목록을 조회합니다. 기본 보호 카테고리를 포함합니다.",
+          security: [{ cookieAuth: [] }],
+          response: {
+            200: assetCategoryListResponseSchema,
+            403: errorResponseSchema,
+          },
+        },
+      },
+      async (_, reply) => {
+        const data = await assetService.getAssetCategories();
+
+        return reply.status(200).send({ data });
+      },
+    );
+
+    // POST /assets/categories - Asset 카테고리 생성 (Admin)
+    typedFastify.post(
+      "/categories",
+      {
+        onRequest: fastify.csrfProtection,
+        preHandler: requireAdmin(adminService),
+        schema: {
+          tags: ["assets"],
+          summary: "Create asset category",
+          description:
+            "사용자 에셋 카테고리를 생성합니다. Admin 권한이 필요합니다.",
+          security: [{ cookieAuth: [] }],
+          body: createAssetCategoryBodySchema,
+          response: {
+            201: assetCategoryResponseSchema,
+            400: errorResponseSchema,
+            403: errorResponseSchema,
+          },
+        },
+      },
+      async (request, reply) => {
+        const category = await assetService.createAssetCategory({
+          name: request.body.name ?? "",
+        });
+
+        return reply.status(201).send(category);
+      },
+    );
+
+    // PATCH /assets/categories/:id - Asset 카테고리 수정 (Admin)
+    typedFastify.patch(
+      "/categories/:id",
+      {
+        onRequest: fastify.csrfProtection,
+        preHandler: requireAdmin(adminService),
+        schema: {
+          tags: ["assets"],
+          summary: "Update asset category",
+          description: "에셋 카테고리 이름 또는 정렬 순서를 수정합니다.",
+          security: [{ cookieAuth: [] }],
+          params: assetCategoryIdParamSchema,
+          body: updateAssetCategoryBodySchema,
+          response: {
+            200: assetCategoryResponseSchema,
+            400: errorResponseSchema,
+            403: errorResponseSchema,
+            404: errorResponseSchema,
+          },
+        },
+      },
+      async (request, reply) => {
+        const { id } = request.params;
+        const category = await assetService.updateAssetCategory({
+          id,
+          ...request.body,
+        });
+
+        return reply.status(200).send(category);
+      },
+    );
+
+    // DELETE /assets/categories/:id - 사용자 Asset 카테고리 삭제 (Admin)
+    typedFastify.delete(
+      "/categories/:id",
+      {
+        onRequest: fastify.csrfProtection,
+        preHandler: requireAdmin(adminService),
+        schema: {
+          tags: ["assets"],
+          summary: "Delete asset category",
+          description:
+            "사용자 추가 에셋 카테고리를 삭제하고 연결된 에셋을 미분류로 이동합니다.",
+          security: [{ cookieAuth: [] }],
+          params: assetCategoryIdParamSchema,
+          response: {
+            204: z.void(),
+            400: errorResponseSchema,
+            403: errorResponseSchema,
+            404: errorResponseSchema,
+          },
+        },
+      },
+      async (request, reply) => {
+        const { id } = request.params;
+        await assetService.deleteAssetCategory(id);
+
+        return reply.status(204).send();
+      },
+    );
+
     // GET /assets/:id - Asset 메타데이터 조회 (Public, 선택)
     typedFastify.get(
       "/:id",
@@ -121,6 +353,66 @@ export function createAssetRoute(
       async (request, reply) => {
         const { id } = request.params;
         const asset = await assetService.getAssetById(id);
+
+        return reply.status(200).send(asset);
+      },
+    );
+
+    // PATCH /assets/bulk/category - Asset 카테고리 벌크 변경 (Admin)
+    typedFastify.patch(
+      "/bulk/category",
+      {
+        onRequest: fastify.csrfProtection,
+        preHandler: requireAdmin(adminService),
+        schema: {
+          tags: ["assets"],
+          summary: "Bulk update asset category",
+          description:
+            "여러 Asset의 카테고리를 한 번에 변경합니다. Admin 권한이 필요합니다.",
+          security: [{ cookieAuth: [] }],
+          body: bulkUpdateAssetCategoryBodySchema,
+          response: {
+            204: z.void(),
+            400: errorResponseSchema,
+            403: errorResponseSchema,
+            404: errorResponseSchema,
+          },
+        },
+      },
+      async (request, reply) => {
+        await assetService.updateAssetsCategory({
+          ids: request.body.ids ?? [],
+          categoryId: request.body.categoryId ?? 0,
+        });
+
+        return reply.status(204).send();
+      },
+    );
+
+    // PATCH /assets/:id - Asset 메타데이터 수정 (Admin)
+    typedFastify.patch(
+      "/:id",
+      {
+        onRequest: fastify.csrfProtection,
+        preHandler: requireAdmin(adminService),
+        schema: {
+          tags: ["assets"],
+          summary: "Update asset metadata",
+          description: "Asset의 별명 또는 카테고리를 수정합니다.",
+          security: [{ cookieAuth: [] }],
+          params: assetIdParamSchema,
+          body: updateAssetBodySchema,
+          response: {
+            200: assetResponseSchema,
+            400: errorResponseSchema,
+            403: errorResponseSchema,
+            404: errorResponseSchema,
+          },
+        },
+      },
+      async (request, reply) => {
+        const { id } = request.params;
+        const asset = await assetService.updateAsset({ id, ...request.body });
 
         return reply.status(200).send(asset);
       },

--- a/src/routes/assets/asset.route.ts
+++ b/src/routes/assets/asset.route.ts
@@ -335,17 +335,21 @@ export function createAssetRoute(
       },
     );
 
-    // GET /assets/:id - Asset 메타데이터 조회 (Public, 선택)
+    // GET /assets/:id - Asset 메타데이터 조회 (Admin)
     typedFastify.get(
       "/:id",
       {
+        preHandler: requireAdmin(adminService),
         schema: {
           tags: ["assets"],
           summary: "Get asset metadata",
-          description: "Asset의 메타데이터를 조회합니다. (URL, 크기, 타입 등)",
+          description:
+            "Asset의 메타데이터를 조회합니다. Admin 권한이 필요합니다.",
+          security: [{ cookieAuth: [] }],
           params: assetIdParamSchema,
           response: {
             200: assetResponseSchema,
+            403: errorResponseSchema,
             404: errorResponseSchema,
           },
         },

--- a/src/routes/assets/asset.schema.ts
+++ b/src/routes/assets/asset.schema.ts
@@ -2,11 +2,65 @@ import { z } from "zod";
 import { PaginationMetaSchema } from "@src/schemas/common";
 
 /**
+ * Asset 카테고리 응답 스키마
+ */
+export const assetCategoryResponseSchema = z.object({
+  id: z.number().describe("에셋 카테고리 ID"),
+  key: z.string().nullable().describe("보호 기본 카테고리 stable key"),
+  name: z.string().describe("에셋 카테고리 이름"),
+  sortOrder: z.number().describe("정렬 순서"),
+  isProtected: z.boolean().describe("기본 보호 카테고리 여부"),
+  createdAt: z.string().describe("생성일 (ISO 8601)"),
+  updatedAt: z.string().describe("수정일 (ISO 8601)"),
+});
+
+/**
+ * Asset 카테고리 생성 요청 스키마
+ */
+export const createAssetCategoryBodySchema = z.object({
+  name: z.string().trim().min(1).max(50).describe("에셋 카테고리 이름"),
+});
+
+/**
+ * Asset 카테고리 수정 요청 스키마
+ */
+export const updateAssetCategoryBodySchema = z
+  .object({
+    name: z
+      .string()
+      .trim()
+      .min(1)
+      .max(50)
+      .optional()
+      .describe("에셋 카테고리 이름"),
+    sortOrder: z.number().int().min(0).optional().describe("정렬 순서"),
+  })
+  .refine((body) => body.name !== undefined || body.sortOrder !== undefined, {
+    message: "At least one field is required.",
+  });
+
+/**
+ * Asset 카테고리 ID 파라미터
+ */
+export const assetCategoryIdParamSchema = z.object({
+  id: z.coerce.number().positive().describe("에셋 카테고리 ID"),
+});
+
+/**
+ * Asset 카테고리 목록 응답 스키마
+ */
+export const assetCategoryListResponseSchema = z.object({
+  data: z.array(assetCategoryResponseSchema),
+});
+
+/**
  * Asset 응답 스키마
  */
 export const assetResponseSchema = z.object({
   id: z.number().describe("에셋 ID"),
   url: z.string().describe("에셋 접근 URL"),
+  displayName: z.string().nullable().describe("관리용 에셋 별명"),
+  category: assetCategoryResponseSchema.describe("에셋 카테고리"),
   mimeType: z.string().describe("MIME 타입 (예: image/jpeg)"),
   sizeBytes: z.number().describe("파일 크기 (바이트)"),
   width: z.number().optional().describe("이미지 너비 (픽셀)"),
@@ -44,6 +98,19 @@ export const assetListQuerySchema = z.object({
     .max(100)
     .default(20)
     .describe("페이지당 항목 수 (최대 100)"),
+  categoryId: z.coerce
+    .number()
+    .int()
+    .positive()
+    .optional()
+    .describe("필터링할 에셋 카테고리 ID"),
+  q: z
+    .string()
+    .trim()
+    .min(1)
+    .max(100)
+    .optional()
+    .describe("별명 또는 파일명 검색어"),
 });
 
 /**
@@ -59,6 +126,44 @@ export const assetListResponseSchema = z.object({
  */
 export const assetIdParamSchema = z.object({
   id: z.coerce.number().positive().describe("에셋 ID"),
+});
+
+/**
+ * 단일 Asset 메타데이터 수정 요청 스키마
+ */
+export const updateAssetBodySchema = z
+  .object({
+    displayName: z
+      .string()
+      .trim()
+      .max(200)
+      .nullable()
+      .optional()
+      .describe("관리용 에셋 별명"),
+    categoryId: z
+      .number()
+      .int()
+      .positive()
+      .optional()
+      .describe("에셋 카테고리 ID"),
+  })
+  .refine(
+    (body) => body.displayName !== undefined || body.categoryId !== undefined,
+    {
+      message: "At least one field is required.",
+    },
+  );
+
+/**
+ * Asset 카테고리 벌크 변경 요청 스키마
+ */
+export const bulkUpdateAssetCategoryBodySchema = z.object({
+  ids: z
+    .array(z.number().positive())
+    .min(1)
+    .max(100)
+    .describe("카테고리를 변경할 에셋 ID 배열 (최대 100개)"),
+  categoryId: z.number().int().positive().describe("변경할 에셋 카테고리 ID"),
 });
 
 /**

--- a/src/routes/assets/asset.service.ts
+++ b/src/routes/assets/asset.service.ts
@@ -1,6 +1,12 @@
-import { eq, inArray, sql, desc } from "drizzle-orm";
+import { and, asc, desc, eq, inArray, sql, type SQL } from "drizzle-orm";
 import { MySql2Database } from "drizzle-orm/mysql2";
-import { assetTable, type Asset } from "@src/db/schema/assets";
+import {
+  assetCategoryTable,
+  assetTable,
+  type Asset,
+  type AssetCategory,
+  type NewAssetCategory,
+} from "@src/db/schema/assets";
 import * as schema from "@src/db/schema/index";
 import { HttpError } from "@src/errors/http-error";
 import {
@@ -14,12 +20,59 @@ import {
 } from "@src/shared/pagination";
 import { toUploadUrl, UPLOADS_URL_PREFIX } from "@src/shared/uploads";
 
+export const DEFAULT_ASSET_CATEGORIES = [
+  { key: "thumbnail", name: "썸네일", sortOrder: 0 },
+  { key: "default", name: "기본", sortOrder: 1 },
+  { key: "uncategorized", name: "미분류", sortOrder: 2 },
+] as const;
+
+export type DefaultAssetCategoryKey =
+  (typeof DEFAULT_ASSET_CATEGORIES)[number]["key"];
+
+export interface AssetCategoryResponse {
+  id: number;
+  key: string | null;
+  name: string;
+  sortOrder: number;
+  isProtected: boolean;
+  createdAt: string;
+  updatedAt: string;
+}
+
+export interface CreateAssetCategoryArgs {
+  name: string;
+}
+
+export interface UpdateAssetCategoryArgs {
+  id: number;
+  name?: string;
+  sortOrder?: number;
+}
+
+export interface UpdateAssetArgs {
+  id: number;
+  displayName?: string | null;
+  categoryId?: number;
+}
+
+export interface BulkUpdateAssetCategoryArgs {
+  ids: number[];
+  categoryId: number;
+}
+
+export interface AssetUploadMetadata {
+  displayName?: string | null;
+  categoryId?: number;
+}
+
 /**
  * 업로드된 Asset 응답
  */
 export interface UploadedAsset {
   id: number;
   url: string;
+  displayName: string | null;
+  category: AssetCategoryResponse;
   mimeType: string;
   sizeBytes: number;
   width?: number;
@@ -39,6 +92,8 @@ export interface AssetListItem extends UploadedAsset {
 export interface GetAssetListQuery {
   page?: number;
   limit?: number;
+  categoryId?: number;
+  q?: string;
 }
 
 /**
@@ -53,9 +108,18 @@ export class AssetService {
   /**
    * 단일 파일 업로드
    * @param buffered 미리 버퍼링된 파일 데이터
+   * @param metadata 파일별 표시명/카테고리 메타데이터
    * @returns 생성된 asset 정보
    */
-  async uploadAsset(buffered: BufferedFile): Promise<UploadedAsset> {
+  async uploadAsset(
+    buffered: BufferedFile,
+    metadata: AssetUploadMetadata = {},
+  ): Promise<UploadedAsset> {
+    const categoryId =
+      metadata.categoryId ?? (await this.getDefaultCategoryId("default"));
+
+    await this.assertAssetCategoryExists(categoryId);
+
     // 1. 파일 저장 (크기/타입 검증 포함, 이미지 크기 추출)
     const { storageKey, mimeType, sizeBytes, width, height } =
       await this.fileStorage.saveFile(buffered);
@@ -64,6 +128,8 @@ export class AssetService {
     const [asset] = await this.db
       .insert(assetTable)
       .values({
+        categoryId,
+        displayName: this.normalizeDisplayName(metadata.displayName),
         storageProvider: "local",
         storageKey,
         mimeType,
@@ -82,10 +148,16 @@ export class AssetService {
   /**
    * 다중 파일 업로드
    * @param files 미리 버퍼링된 파일 데이터 배열
+   * @param metadata 파일 순서와 매칭되는 메타데이터 배열
    * @returns 생성된 asset 배열
    */
-  async uploadAssets(files: BufferedFile[]): Promise<UploadedAsset[]> {
-    return Promise.all(files.map((file) => this.uploadAsset(file)));
+  async uploadAssets(
+    files: BufferedFile[],
+    metadata: AssetUploadMetadata[] = [],
+  ): Promise<UploadedAsset[]> {
+    return Promise.all(
+      files.map((file, index) => this.uploadAsset(file, metadata[index])),
+    );
   }
 
   /**
@@ -94,16 +166,26 @@ export class AssetService {
    * @returns asset 정보 (URL 포함)
    */
   async getAssetById(id: number): Promise<UploadedAsset> {
-    const [asset] = await this.db
-      .select()
+    await this.ensureDefaultCategories();
+
+    const [row] = await this.db
+      .select({ asset: assetTable, category: assetCategoryTable })
       .from(assetTable)
+      .leftJoin(
+        assetCategoryTable,
+        eq(assetTable.categoryId, assetCategoryTable.id),
+      )
       .where(eq(assetTable.id, id));
 
-    if (!asset) {
+    if (!row?.asset) {
       throw HttpError.notFound(`Asset not found: ${id}`);
     }
 
-    return this.toUploadedAsset(asset);
+    if (!row.category) {
+      throw HttpError.internal("Asset category not found.");
+    }
+
+    return this.toUploadedAsset(row.asset, row.category);
   }
 
   /**
@@ -164,33 +246,319 @@ export class AssetService {
   async getAssetList(
     query: GetAssetListQuery,
   ): Promise<PaginatedResponse<AssetListItem>> {
+    await this.ensureDefaultCategories();
+
     const page = query.page ?? 1;
     const limit = query.limit ?? 20;
     const offset = calculateOffset(page, limit);
+    const where = this.buildAssetListWhere(query);
 
     const [{ total }] = await this.db
       .select({ total: sql<number>`COUNT(*)` })
-      .from(assetTable);
+      .from(assetTable)
+      .where(where);
 
     const assets = await this.db
-      .select()
+      .select({ asset: assetTable, category: assetCategoryTable })
       .from(assetTable)
+      .leftJoin(
+        assetCategoryTable,
+        eq(assetTable.categoryId, assetCategoryTable.id),
+      )
+      .where(where)
       .orderBy(desc(assetTable.createdAt))
       .limit(limit)
       .offset(offset);
 
-    const data = assets.map((asset) => this.toAssetListItem(asset));
+    const data = assets.map((row) => {
+      if (!row.category) {
+        throw HttpError.internal("Asset category not found.");
+      }
+
+      return this.toAssetListItem(row.asset, row.category);
+    });
 
     return buildPaginatedResponse(data, total, page, limit);
   }
 
   /**
+   * 에셋 카테고리 목록 조회
+   */
+  async getAssetCategories(): Promise<AssetCategoryResponse[]> {
+    await this.ensureDefaultCategories();
+
+    const categories = await this.db
+      .select()
+      .from(assetCategoryTable)
+      .orderBy(asc(assetCategoryTable.sortOrder), asc(assetCategoryTable.id));
+
+    return categories.map((category) => this.toAssetCategoryResponse(category));
+  }
+
+  /**
+   * 사용자 에셋 카테고리 생성
+   */
+  async createAssetCategory(
+    args: CreateAssetCategoryArgs,
+  ): Promise<AssetCategoryResponse> {
+    await this.ensureDefaultCategories();
+
+    const name = this.normalizeCategoryName(args.name);
+    const [maxOrder] = await this.db
+      .select({
+        max: sql<number>`COALESCE(MAX(${assetCategoryTable.sortOrder}), 0)`,
+      })
+      .from(assetCategoryTable);
+
+    const [result] = await this.db.insert(assetCategoryTable).values({
+      key: null,
+      name,
+      sortOrder: (maxOrder?.max ?? 0) + 1,
+      isProtected: false,
+    });
+
+    return await this.getAssetCategoryById(Number(result.insertId));
+  }
+
+  /**
+   * 에셋 카테고리 수정
+   */
+  async updateAssetCategory(
+    args: UpdateAssetCategoryArgs,
+  ): Promise<AssetCategoryResponse> {
+    await this.ensureDefaultCategories();
+
+    const [existing] = await this.db
+      .select()
+      .from(assetCategoryTable)
+      .where(eq(assetCategoryTable.id, args.id))
+      .limit(1);
+
+    if (!existing) {
+      throw HttpError.notFound("Asset category not found.");
+    }
+
+    const updates: Partial<NewAssetCategory> = {};
+    if (args.name !== undefined) {
+      updates.name = this.normalizeCategoryName(args.name);
+    }
+    if (args.sortOrder !== undefined) {
+      updates.sortOrder = args.sortOrder;
+    }
+
+    if (Object.keys(updates).length > 0) {
+      await this.db
+        .update(assetCategoryTable)
+        .set(updates)
+        .where(eq(assetCategoryTable.id, args.id));
+    }
+
+    return await this.getAssetCategoryById(args.id);
+  }
+
+  /**
+   * 사용자 에셋 카테고리 삭제 후 연결 에셋은 미분류로 이동
+   */
+  async deleteAssetCategory(id: number): Promise<void> {
+    await this.ensureDefaultCategories();
+
+    const uncategorizedId = await this.getDefaultCategoryId("uncategorized");
+
+    await this.db.transaction(async (tx) => {
+      const [category] = await tx
+        .select()
+        .from(assetCategoryTable)
+        .where(eq(assetCategoryTable.id, id))
+        .limit(1)
+        .for("update");
+
+      if (!category) {
+        throw HttpError.notFound("Asset category not found.");
+      }
+
+      if (category.isProtected) {
+        throw HttpError.badRequest(
+          "Protected asset categories cannot be deleted.",
+        );
+      }
+
+      await tx
+        .update(assetTable)
+        .set({ categoryId: uncategorizedId })
+        .where(eq(assetTable.categoryId, id));
+
+      await tx.delete(assetCategoryTable).where(eq(assetCategoryTable.id, id));
+    });
+  }
+
+  /**
+   * 단일 에셋 메타데이터 수정
+   */
+  async updateAsset(args: UpdateAssetArgs): Promise<UploadedAsset> {
+    await this.ensureDefaultCategories();
+
+    const [existing] = await this.db
+      .select({ id: assetTable.id })
+      .from(assetTable)
+      .where(eq(assetTable.id, args.id))
+      .limit(1);
+
+    if (!existing) {
+      throw HttpError.notFound("Asset not found.");
+    }
+
+    const updates: Partial<typeof assetTable.$inferInsert> = {};
+    if (args.displayName !== undefined) {
+      updates.displayName = this.normalizeDisplayName(args.displayName);
+    }
+    if (args.categoryId !== undefined) {
+      await this.assertAssetCategoryExists(args.categoryId);
+      updates.categoryId = args.categoryId;
+    }
+
+    if (Object.keys(updates).length > 0) {
+      await this.db
+        .update(assetTable)
+        .set(updates)
+        .where(eq(assetTable.id, args.id));
+    }
+
+    return await this.getAssetById(args.id);
+  }
+
+  /**
+   * 여러 에셋의 카테고리 일괄 변경
+   */
+  async updateAssetsCategory(args: BulkUpdateAssetCategoryArgs): Promise<void> {
+    await this.ensureDefaultCategories();
+    await this.assertAssetCategoryExists(args.categoryId);
+
+    const uniqueIds = [...new Set(args.ids)];
+    if (uniqueIds.length !== args.ids.length) {
+      throw HttpError.badRequest("Duplicate asset IDs are not allowed.");
+    }
+
+    const existing = await this.db
+      .select({ id: assetTable.id })
+      .from(assetTable)
+      .where(inArray(assetTable.id, uniqueIds));
+
+    if (existing.length !== uniqueIds.length) {
+      throw HttpError.notFound("One or more assets not found.");
+    }
+
+    await this.db
+      .update(assetTable)
+      .set({ categoryId: args.categoryId })
+      .where(inArray(assetTable.id, uniqueIds));
+  }
+
+  private async getAssetCategoryById(
+    id: number,
+  ): Promise<AssetCategoryResponse> {
+    const [category] = await this.db
+      .select()
+      .from(assetCategoryTable)
+      .where(eq(assetCategoryTable.id, id))
+      .limit(1);
+
+    if (!category) {
+      throw HttpError.notFound("Asset category not found.");
+    }
+
+    return this.toAssetCategoryResponse(category);
+  }
+
+  private async ensureDefaultCategories(): Promise<void> {
+    const defaults = DEFAULT_ASSET_CATEGORIES.map((category) => category.key);
+    const existing = await this.db
+      .select({ key: assetCategoryTable.key })
+      .from(assetCategoryTable)
+      .where(inArray(assetCategoryTable.key, defaults));
+
+    const existingKeys = new Set(existing.map((category) => category.key));
+
+    for (const category of DEFAULT_ASSET_CATEGORIES) {
+      if (existingKeys.has(category.key)) {
+        continue;
+      }
+
+      try {
+        await this.db.insert(assetCategoryTable).values({
+          key: category.key,
+          name: category.name,
+          sortOrder: category.sortOrder,
+          isProtected: true,
+        });
+      } catch (error) {
+        if (!this.isDuplicateEntry(error)) {
+          throw error;
+        }
+      }
+    }
+  }
+
+  private async getDefaultCategoryId(
+    key: DefaultAssetCategoryKey,
+  ): Promise<number> {
+    await this.ensureDefaultCategories();
+
+    const [category] = await this.db
+      .select({ id: assetCategoryTable.id })
+      .from(assetCategoryTable)
+      .where(eq(assetCategoryTable.key, key))
+      .limit(1);
+
+    if (!category) {
+      throw HttpError.internal(`Default asset category missing: ${key}`);
+    }
+
+    return category.id;
+  }
+
+  private async assertAssetCategoryExists(categoryId: number): Promise<void> {
+    const [category] = await this.db
+      .select({ id: assetCategoryTable.id })
+      .from(assetCategoryTable)
+      .where(eq(assetCategoryTable.id, categoryId))
+      .limit(1);
+
+    if (!category) {
+      throw HttpError.badRequest("Asset category not found.");
+    }
+  }
+
+  private buildAssetListWhere(query: GetAssetListQuery): SQL | undefined {
+    const conditions: SQL[] = [];
+
+    if (query.categoryId !== undefined) {
+      conditions.push(eq(assetTable.categoryId, query.categoryId));
+    }
+
+    const search = query.q?.trim();
+    if (search) {
+      const pattern = `%${search}%`;
+      conditions.push(sql`(
+        ${assetTable.displayName} LIKE ${pattern}
+        OR ${assetTable.storageKey} LIKE ${pattern}
+      )`);
+    }
+
+    return conditions.length > 0 ? and(...conditions) : undefined;
+  }
+
+  /**
    * Asset을 UploadedAsset 형태로 변환
    */
-  private toUploadedAsset(asset: Asset): UploadedAsset {
+  private toUploadedAsset(
+    asset: Asset,
+    category: AssetCategory,
+  ): UploadedAsset {
     return {
       id: asset.id,
       url: toUploadUrl(asset.storageKey),
+      displayName: asset.displayName,
+      category: this.toAssetCategoryResponse(category),
       mimeType: asset.mimeType,
       sizeBytes: asset.sizeBytes,
       width: asset.width ?? undefined,
@@ -201,10 +569,58 @@ export class AssetService {
   /**
    * Asset을 AssetListItem 형태로 변환 (createdAt 포함)
    */
-  private toAssetListItem(asset: Asset): AssetListItem {
+  private toAssetListItem(
+    asset: Asset,
+    category: AssetCategory,
+  ): AssetListItem {
     return {
-      ...this.toUploadedAsset(asset),
+      ...this.toUploadedAsset(asset, category),
       createdAt: asset.createdAt.toISOString(),
     };
+  }
+
+  private toAssetCategoryResponse(
+    category: AssetCategory,
+  ): AssetCategoryResponse {
+    return {
+      id: category.id,
+      key: category.key,
+      name: category.name,
+      sortOrder: category.sortOrder,
+      isProtected: category.isProtected,
+      createdAt: category.createdAt.toISOString(),
+      updatedAt: category.updatedAt.toISOString(),
+    };
+  }
+
+  private normalizeDisplayName(
+    value: string | null | undefined,
+  ): string | null {
+    if (value === undefined || value === null) {
+      return null;
+    }
+
+    const trimmed = value.trim();
+
+    return trimmed.length > 0 ? trimmed : null;
+  }
+
+  private normalizeCategoryName(name: string): string {
+    const trimmed = name.trim();
+
+    if (!trimmed) {
+      throw HttpError.badRequest("Asset category name is required.");
+    }
+
+    return trimmed;
+  }
+
+  private isDuplicateEntry(error: unknown): error is { code: string } {
+    return (
+      typeof error === "object" &&
+      error !== null &&
+      "code" in error &&
+      (error as { code?: string }).code === "ER_DUP_ENTRY"
+    );
   }
 }

--- a/src/routes/assets/asset.service.ts
+++ b/src/routes/assets/asset.service.ts
@@ -141,8 +141,26 @@ export class AssetService {
     );
     const assets: UploadedAsset[] = [];
 
-    for (const [index, file] of files.entries()) {
-      assets.push(await this.savePreparedAsset(file, preparedMetadata[index]!));
+    try {
+      for (const [index, file] of files.entries()) {
+        assets.push(
+          await this.savePreparedAsset(file, preparedMetadata[index]!),
+        );
+      }
+    } catch (error) {
+      await Promise.all(
+        assets.map(async (asset) => {
+          try {
+            await this.deleteAsset(asset.id);
+          } catch (cleanupError) {
+            console.error(
+              `Failed to clean up asset after upload failure: ${asset.id}`,
+              cleanupError,
+            );
+          }
+        }),
+      );
+      throw error;
     }
 
     return assets;
@@ -449,25 +467,37 @@ export class AssetService {
     const { storageKey, mimeType, sizeBytes, width, height } =
       await this.fileStorage.saveFile(buffered);
 
-    // 2. DB 레코드 생성
-    const [asset] = await this.db
-      .insert(assetTable)
-      .values({
-        categoryId: metadata.categoryId,
-        displayName: metadata.displayName,
-        storageProvider: "local",
-        storageKey,
-        mimeType,
-        sizeBytes,
-        width: width ?? null,
-        height: height ?? null,
-      })
-      .$returningId();
+    try {
+      // 2. DB 레코드 생성
+      const [asset] = await this.db
+        .insert(assetTable)
+        .values({
+          categoryId: metadata.categoryId,
+          displayName: metadata.displayName,
+          storageProvider: "local",
+          storageKey,
+          mimeType,
+          sizeBytes,
+          width: width ?? null,
+          height: height ?? null,
+        })
+        .$returningId();
 
-    // 3. 생성된 asset 조회 (전체 정보)
-    const createdAsset = await this.getAssetById(asset.id);
+      // 3. 생성된 asset 조회 (전체 정보)
+      const createdAsset = await this.getAssetById(asset.id);
 
-    return createdAsset;
+      return createdAsset;
+    } catch (error) {
+      try {
+        await this.fileStorage.deleteFile(storageKey);
+      } catch (cleanupError) {
+        console.error(
+          `Failed to clean up uploaded file after DB failure: ${storageKey}`,
+          cleanupError,
+        );
+      }
+      throw error;
+    }
   }
 
   private async getAssetCategoryById(

--- a/src/routes/assets/asset.service.ts
+++ b/src/routes/assets/asset.service.ts
@@ -65,6 +65,11 @@ export interface AssetUploadMetadata {
   categoryId?: number;
 }
 
+interface PreparedAssetUploadMetadata {
+  displayName: string | null;
+  categoryId: number;
+}
+
 /**
  * 업로드된 Asset 응답
  */
@@ -115,35 +120,9 @@ export class AssetService {
     buffered: BufferedFile,
     metadata: AssetUploadMetadata = {},
   ): Promise<UploadedAsset> {
-    const categoryId =
-      metadata.categoryId ?? (await this.getDefaultCategoryId("default"));
-    const displayName = this.normalizeDisplayName(metadata.displayName);
+    const [preparedMetadata] = await this.prepareUploadMetadata(1, [metadata]);
 
-    await this.assertAssetCategoryExists(categoryId);
-
-    // 1. 파일 저장 (크기/타입 검증 포함, 이미지 크기 추출)
-    const { storageKey, mimeType, sizeBytes, width, height } =
-      await this.fileStorage.saveFile(buffered);
-
-    // 2. DB 레코드 생성
-    const [asset] = await this.db
-      .insert(assetTable)
-      .values({
-        categoryId,
-        displayName,
-        storageProvider: "local",
-        storageKey,
-        mimeType,
-        sizeBytes,
-        width: width ?? null,
-        height: height ?? null,
-      })
-      .$returningId();
-
-    // 3. 생성된 asset 조회 (전체 정보)
-    const createdAsset = await this.getAssetById(asset.id);
-
-    return createdAsset;
+    return await this.savePreparedAsset(buffered, preparedMetadata);
   }
 
   /**
@@ -156,9 +135,17 @@ export class AssetService {
     files: BufferedFile[],
     metadata: AssetUploadMetadata[] = [],
   ): Promise<UploadedAsset[]> {
-    return Promise.all(
-      files.map((file, index) => this.uploadAsset(file, metadata[index])),
+    const preparedMetadata = await this.prepareUploadMetadata(
+      files.length,
+      metadata,
     );
+    const assets: UploadedAsset[] = [];
+
+    for (const [index, file] of files.entries()) {
+      assets.push(await this.savePreparedAsset(file, preparedMetadata[index]!));
+    }
+
+    return assets;
   }
 
   /**
@@ -454,6 +441,35 @@ export class AssetService {
       .where(inArray(assetTable.id, uniqueIds));
   }
 
+  private async savePreparedAsset(
+    buffered: BufferedFile,
+    metadata: PreparedAssetUploadMetadata,
+  ): Promise<UploadedAsset> {
+    // 1. 파일 저장 (크기/타입 검증 포함, 이미지 크기 추출)
+    const { storageKey, mimeType, sizeBytes, width, height } =
+      await this.fileStorage.saveFile(buffered);
+
+    // 2. DB 레코드 생성
+    const [asset] = await this.db
+      .insert(assetTable)
+      .values({
+        categoryId: metadata.categoryId,
+        displayName: metadata.displayName,
+        storageProvider: "local",
+        storageKey,
+        mimeType,
+        sizeBytes,
+        width: width ?? null,
+        height: height ?? null,
+      })
+      .$returningId();
+
+    // 3. 생성된 asset 조회 (전체 정보)
+    const createdAsset = await this.getAssetById(asset.id);
+
+    return createdAsset;
+  }
+
   private async getAssetCategoryById(
     id: number,
   ): Promise<AssetCategoryResponse> {
@@ -527,6 +543,41 @@ export class AssetService {
     if (!category) {
       throw HttpError.badRequest("Asset category not found.");
     }
+  }
+
+  private async assertAssetCategoriesExist(
+    categoryIds: number[],
+  ): Promise<void> {
+    const uniqueIds = [...new Set(categoryIds)];
+    if (uniqueIds.length === 0) {
+      return;
+    }
+
+    const categories = await this.db
+      .select({ id: assetCategoryTable.id })
+      .from(assetCategoryTable)
+      .where(inArray(assetCategoryTable.id, uniqueIds));
+
+    if (categories.length !== uniqueIds.length) {
+      throw HttpError.badRequest("Asset category not found.");
+    }
+  }
+
+  private async prepareUploadMetadata(
+    fileCount: number,
+    metadata: AssetUploadMetadata[],
+  ): Promise<PreparedAssetUploadMetadata[]> {
+    const defaultCategoryId = await this.getDefaultCategoryId("default");
+    const preparedMetadata = Array.from({ length: fileCount }, (_, index) => ({
+      displayName: this.normalizeDisplayName(metadata[index]?.displayName),
+      categoryId: metadata[index]?.categoryId ?? defaultCategoryId,
+    }));
+
+    await this.assertAssetCategoriesExist(
+      preparedMetadata.map((entry) => entry.categoryId),
+    );
+
+    return preparedMetadata;
   }
 
   private buildAssetListWhere(query: GetAssetListQuery): SQL | undefined {

--- a/src/routes/assets/asset.service.ts
+++ b/src/routes/assets/asset.service.ts
@@ -117,6 +117,7 @@ export class AssetService {
   ): Promise<UploadedAsset> {
     const categoryId =
       metadata.categoryId ?? (await this.getDefaultCategoryId("default"));
+    const displayName = this.normalizeDisplayName(metadata.displayName);
 
     await this.assertAssetCategoryExists(categoryId);
 
@@ -129,7 +130,7 @@ export class AssetService {
       .insert(assetTable)
       .values({
         categoryId,
-        displayName: this.normalizeDisplayName(metadata.displayName),
+        displayName,
         storageProvider: "local",
         storageKey,
         mimeType,
@@ -601,6 +602,11 @@ export class AssetService {
     }
 
     const trimmed = value.trim();
+    if (trimmed.length > 200) {
+      throw HttpError.badRequest(
+        "Asset displayName cannot exceed 200 characters.",
+      );
+    }
 
     return trimmed.length > 0 ? trimmed : null;
   }

--- a/test/helpers/seed.ts
+++ b/test/helpers/seed.ts
@@ -3,10 +3,12 @@ import { TEST_ADMIN_PASSWORD, TEST_ADMIN_USERNAME } from "./app";
 import { db } from "@src/db/client";
 import {
   adminTable,
+  assetCategoryTable,
   assetTable,
   categoryTable,
   commentTable,
   NewAsset,
+  NewAssetCategory,
   NewCategory,
   NewComment,
   NewOAuthAccount,
@@ -27,6 +29,7 @@ const ALL_TABLES = [
   "stats_daily_tb",
   "post_tb",
   "asset_tb",
+  "asset_category_tb",
   "tag_tb",
   "category_tb",
   "oauth_account_tb",
@@ -198,8 +201,11 @@ export async function seedComment(
 export async function seedAsset(
   overrides?: Partial<NewAsset>,
 ): Promise<typeof assetTable.$inferSelect> {
+  const categoryId =
+    overrides?.categoryId ?? (await seedAssetCategory({ key: null })).id;
   const suffix = `${Date.now()}-${Math.random().toString(36).slice(2, 6)}`;
   const values: NewAsset = {
+    categoryId,
     storageProvider: "local",
     storageKey: `2026/01/test-${suffix}.png`,
     mimeType: "image/png",
@@ -216,4 +222,28 @@ export async function seedAsset(
     .where(eq(assetTable.id, Number(result.insertId)));
 
   return asset!;
+}
+
+/**
+ * 테스트 Asset Category 생성
+ */
+export async function seedAssetCategory(
+  overrides?: Partial<NewAssetCategory>,
+): Promise<typeof assetCategoryTable.$inferSelect> {
+  const suffix = `${Date.now()}-${Math.random().toString(36).slice(2, 6)}`;
+  const values: NewAssetCategory = {
+    key: null,
+    name: `Test Asset Category ${suffix}`,
+    sortOrder: 0,
+    isProtected: false,
+    ...overrides,
+  };
+
+  const [result] = await db.insert(assetCategoryTable).values(values);
+  const [category] = await db
+    .select()
+    .from(assetCategoryTable)
+    .where(eq(assetCategoryTable.id, Number(result.insertId)));
+
+  return category!;
 }

--- a/test/routes/assets.test.ts
+++ b/test/routes/assets.test.ts
@@ -483,6 +483,45 @@ describe("Asset Routes", () => {
       expect(listRes.json().meta.total).toBe(0);
     });
 
+    it("다중 업로드 중 뒤 파일 검증이 실패하면 앞 파일 에셋도 정리한다", async () => {
+      const boundary = "testboundary";
+      const payload = buildMultipart(
+        [
+          {
+            fieldName: "files",
+            fileName: "valid.png",
+            content: TINY_PNG,
+            mimeType: "image/png",
+          },
+          {
+            fieldName: "files",
+            fileName: "invalid.png",
+            content: Buffer.from("not actually a png"),
+            mimeType: "image/png",
+          },
+        ],
+        boundary,
+      );
+      const res = await app.inject({
+        method: "POST",
+        url: "/assets/upload",
+        headers: {
+          cookie: authCookie,
+          "content-type": `multipart/form-data; boundary=${boundary}`,
+        },
+        payload,
+      });
+
+      expect(res.statusCode).toBe(400);
+
+      const listRes = await app.inject({
+        method: "GET",
+        url: "/assets",
+        headers: { cookie: authCookie },
+      });
+      expect(listRes.json().meta.total).toBe(0);
+    });
+
     it("업로드 후 반환된 /uploads URL로 정적 접근 가능", async () => {
       const boundary = "testboundary";
       const payload = buildMultipart(

--- a/test/routes/assets.test.ts
+++ b/test/routes/assets.test.ts
@@ -407,6 +407,33 @@ describe("Asset Routes", () => {
       });
     });
 
+    it("displayName이 200자를 초과하면 업로드를 거부한다", async () => {
+      const boundary = "testboundary";
+      const payload = buildMultipart(
+        [
+          {
+            fieldName: "files",
+            fileName: "too-long-name.png",
+            content: TINY_PNG,
+            mimeType: "image/png",
+          },
+        ],
+        boundary,
+        [{ name: "displayName", value: "a".repeat(201) }],
+      );
+      const res = await app.inject({
+        method: "POST",
+        url: "/assets/upload",
+        headers: {
+          cookie: authCookie,
+          "content-type": `multipart/form-data; boundary=${boundary}`,
+        },
+        payload,
+      });
+
+      expect(res.statusCode).toBe(400);
+    });
+
     it("업로드 후 반환된 /uploads URL로 정적 접근 가능", async () => {
       const boundary = "testboundary";
       const payload = buildMultipart(

--- a/test/routes/assets.test.ts
+++ b/test/routes/assets.test.ts
@@ -277,6 +277,7 @@ describe("Asset Routes", () => {
       const assetRes = await app.inject({
         method: "GET",
         url: `/assets/${asset.id}`,
+        headers: { cookie: authCookie },
       });
       expect(assetRes.statusCode).toBe(200);
       expect(assetRes.json().category).toMatchObject({
@@ -432,6 +433,54 @@ describe("Asset Routes", () => {
       });
 
       expect(res.statusCode).toBe(400);
+    });
+
+    it("다중 업로드 메타데이터가 유효하지 않으면 일부 에셋도 생성하지 않는다", async () => {
+      const boundary = "testboundary";
+      const payload = buildMultipart(
+        [
+          {
+            fieldName: "files",
+            fileName: "valid-name.png",
+            content: TINY_PNG,
+            mimeType: "image/png",
+          },
+          {
+            fieldName: "files",
+            fileName: "invalid-name.png",
+            content: TINY_PNG,
+            mimeType: "image/png",
+          },
+        ],
+        boundary,
+        [
+          {
+            name: "metadata",
+            value: JSON.stringify([
+              { displayName: "valid" },
+              { displayName: "b".repeat(201) },
+            ]),
+          },
+        ],
+      );
+      const res = await app.inject({
+        method: "POST",
+        url: "/assets/upload",
+        headers: {
+          cookie: authCookie,
+          "content-type": `multipart/form-data; boundary=${boundary}`,
+        },
+        payload,
+      });
+
+      expect(res.statusCode).toBe(400);
+
+      const listRes = await app.inject({
+        method: "GET",
+        url: "/assets",
+        headers: { cookie: authCookie },
+      });
+      expect(listRes.json().meta.total).toBe(0);
     });
 
     it("업로드 후 반환된 /uploads URL로 정적 접근 가능", async () => {
@@ -648,11 +697,22 @@ describe("Asset Routes", () => {
   // ===== GET /assets/:id =====
 
   describe("GET /assets/:id", () => {
+    it("인증 없이 → 403", async () => {
+      const asset = await seedAsset();
+      const res = await app.inject({
+        method: "GET",
+        url: `/assets/${asset.id}`,
+      });
+
+      expect(res.statusCode).toBe(403);
+    });
+
     it("존재하는 asset → 200", async () => {
       const asset = await seedAsset({ width: 800, height: 600 });
       const res = await app.inject({
         method: "GET",
         url: `/assets/${asset.id}`,
+        headers: { cookie: authCookie },
       });
       expect(res.statusCode).toBe(200);
       const body = res.json();
@@ -667,6 +727,7 @@ describe("Asset Routes", () => {
       const res = await app.inject({
         method: "GET",
         url: "/assets/999999",
+        headers: { cookie: authCookie },
       });
       expect(res.statusCode).toBe(404);
     });
@@ -772,6 +833,7 @@ describe("Asset Routes", () => {
       const check = await app.inject({
         method: "GET",
         url: `/assets/${asset.id}`,
+        headers: { cookie: authCookie },
       });
       expect(check.statusCode).toBe(404);
     });
@@ -827,10 +889,12 @@ describe("Asset Routes", () => {
       const check1 = await app.inject({
         method: "GET",
         url: `/assets/${a1.id}`,
+        headers: { cookie: authCookie },
       });
       const check2 = await app.inject({
         method: "GET",
         url: `/assets/${a2.id}`,
+        headers: { cookie: authCookie },
       });
       expect(check1.statusCode).toBe(404);
       expect(check2.statusCode).toBe(404);
@@ -839,6 +903,7 @@ describe("Asset Routes", () => {
       const check3 = await app.inject({
         method: "GET",
         url: `/assets/${a3.id}`,
+        headers: { cookie: authCookie },
       });
       expect(check3.statusCode).toBe(200);
     });

--- a/test/routes/assets.test.ts
+++ b/test/routes/assets.test.ts
@@ -1,10 +1,24 @@
 import * as fs from "fs/promises";
 import * as path from "path";
 import { FastifyInstance } from "fastify";
-import { describe, it, expect, beforeAll, afterAll, beforeEach, afterEach, vi } from "vitest";
+import {
+  describe,
+  it,
+  expect,
+  beforeAll,
+  afterAll,
+  beforeEach,
+  afterEach,
+  vi,
+} from "vitest";
 import { getUploadDir } from "@src/shared/uploads";
 import { createTestApp, cleanup, injectAuth } from "@test/helpers/app";
-import { seedAdmin, seedAsset, truncateAll } from "@test/helpers/seed";
+import {
+  seedAdmin,
+  seedAsset,
+  seedAssetCategory,
+  truncateAll,
+} from "@test/helpers/seed";
 
 /** 1x1 PNG (base64) */
 const TINY_PNG_BASE64 =
@@ -37,8 +51,16 @@ function buildMultipart(
     mimeType: string;
   }>,
   boundary: string,
+  fields: Array<{ name: string; value: string }> = [],
 ): Buffer {
   const parts: Buffer[] = [];
+  for (const field of fields) {
+    parts.push(
+      Buffer.from(
+        `--${boundary}\r\nContent-Disposition: form-data; name="${field.name}"\r\n\r\n${field.value}\r\n`,
+      ),
+    );
+  }
   for (const file of files) {
     parts.push(
       Buffer.from(
@@ -122,6 +144,146 @@ describe("Asset Routes", () => {
         totalPages: 2,
       });
     });
+
+    it("categoryId와 q로 목록 필터링", async () => {
+      const thumbnail = await seedAssetCategory({
+        name: "Thumbnails",
+        key: "thumbnail-test",
+        isProtected: true,
+      });
+      const article = await seedAssetCategory({ name: "Article Images" });
+      await seedAsset({
+        categoryId: thumbnail.id,
+        displayName: "Hero Thumbnail",
+        storageKey: "2026/01/hero-thumb.png",
+      });
+      await seedAsset({
+        categoryId: article.id,
+        displayName: "본문 이미지",
+        storageKey: "2026/01/body-image.png",
+      });
+
+      const res = await app.inject({
+        method: "GET",
+        url: `/assets?categoryId=${thumbnail.id}&q=Hero`,
+        headers: { cookie: authCookie },
+      });
+
+      expect(res.statusCode).toBe(200);
+      const body = res.json();
+      expect(body.data).toHaveLength(1);
+      expect(body.data[0]).toMatchObject({
+        displayName: "Hero Thumbnail",
+        category: { id: thumbnail.id, name: "Thumbnails" },
+      });
+    });
+  });
+
+  // ===== /assets/categories =====
+
+  describe("/assets/categories", () => {
+    it("기본 보호 카테고리 3개를 보장한다", async () => {
+      const res = await app.inject({
+        method: "GET",
+        url: "/assets/categories",
+        headers: { cookie: authCookie },
+      });
+
+      expect(res.statusCode).toBe(200);
+      const body = res.json();
+      expect(body.data).toEqual(
+        expect.arrayContaining([
+          expect.objectContaining({
+            key: "thumbnail",
+            name: "썸네일",
+            isProtected: true,
+          }),
+          expect.objectContaining({
+            key: "default",
+            name: "기본",
+            isProtected: true,
+          }),
+          expect.objectContaining({
+            key: "uncategorized",
+            name: "미분류",
+            isProtected: true,
+          }),
+        ]),
+      );
+    });
+
+    it("사용자 카테고리 생성/수정 → 201/200", async () => {
+      const createRes = await app.inject({
+        method: "POST",
+        url: "/assets/categories",
+        headers: { cookie: authCookie },
+        payload: { name: "본문" },
+      });
+
+      expect(createRes.statusCode).toBe(201);
+      const created = createRes.json();
+      expect(created).toMatchObject({
+        key: null,
+        name: "본문",
+        isProtected: false,
+      });
+
+      const updateRes = await app.inject({
+        method: "PATCH",
+        url: `/assets/categories/${created.id}`,
+        headers: { cookie: authCookie },
+        payload: { name: "본문 이미지", sortOrder: 10 },
+      });
+
+      expect(updateRes.statusCode).toBe(200);
+      expect(updateRes.json()).toMatchObject({
+        id: created.id,
+        name: "본문 이미지",
+        sortOrder: 10,
+      });
+    });
+
+    it("보호 카테고리는 삭제할 수 없다", async () => {
+      const listRes = await app.inject({
+        method: "GET",
+        url: "/assets/categories",
+        headers: { cookie: authCookie },
+      });
+      const thumbnail = listRes
+        .json()
+        .data.find((category: { key: string }) => category.key === "thumbnail");
+
+      const res = await app.inject({
+        method: "DELETE",
+        url: `/assets/categories/${thumbnail.id}`,
+        headers: { cookie: authCookie },
+      });
+
+      expect(res.statusCode).toBe(400);
+    });
+
+    it("사용자 카테고리 삭제 시 연결 에셋은 미분류로 이동한다", async () => {
+      const category = await seedAssetCategory({ name: "Delete Me" });
+      const asset = await seedAsset({ categoryId: category.id });
+
+      const res = await app.inject({
+        method: "DELETE",
+        url: `/assets/categories/${category.id}`,
+        headers: { cookie: authCookie },
+      });
+
+      expect(res.statusCode).toBe(204);
+
+      const assetRes = await app.inject({
+        method: "GET",
+        url: `/assets/${asset.id}`,
+      });
+      expect(assetRes.statusCode).toBe(200);
+      expect(assetRes.json().category).toMatchObject({
+        key: "uncategorized",
+        name: "미분류",
+      });
+    });
   });
 
   // ===== POST /assets/upload =====
@@ -150,13 +312,22 @@ describe("Asset Routes", () => {
     it("인증 없이 → 403", async () => {
       const boundary = "testboundary";
       const payload = buildMultipart(
-        [{ fieldName: "files", fileName: "a.png", content: TINY_PNG, mimeType: "image/png" }],
+        [
+          {
+            fieldName: "files",
+            fileName: "a.png",
+            content: TINY_PNG,
+            mimeType: "image/png",
+          },
+        ],
         boundary,
       );
       const res = await app.inject({
         method: "POST",
         url: "/assets/upload",
-        headers: { "content-type": `multipart/form-data; boundary=${boundary}` },
+        headers: {
+          "content-type": `multipart/form-data; boundary=${boundary}`,
+        },
         payload,
       });
       expect(res.statusCode).toBe(403);
@@ -165,7 +336,14 @@ describe("Asset Routes", () => {
     it("PNG 업로드 → 201 + width/height 추출", async () => {
       const boundary = "testboundary";
       const payload = buildMultipart(
-        [{ fieldName: "files", fileName: "test.png", content: TINY_PNG, mimeType: "image/png" }],
+        [
+          {
+            fieldName: "files",
+            fileName: "test.png",
+            content: TINY_PNG,
+            mimeType: "image/png",
+          },
+        ],
         boundary,
       );
       const res = await app.inject({
@@ -185,12 +363,61 @@ describe("Asset Routes", () => {
       expect(asset.url).toMatch(/^\/uploads\/\d{4}\/\d{2}\//);
       expect(asset.width).toBe(1);
       expect(asset.height).toBe(1);
+      expect(asset.displayName).toBeNull();
+      expect(asset.category).toMatchObject({ key: "default", name: "기본" });
+    });
+
+    it("파일별 displayName/categoryId 메타데이터를 저장한다", async () => {
+      const category = await seedAssetCategory({ name: "Upload Target" });
+      const boundary = "testboundary";
+      const payload = buildMultipart(
+        [
+          {
+            fieldName: "files",
+            fileName: "named.png",
+            content: TINY_PNG,
+            mimeType: "image/png",
+          },
+        ],
+        boundary,
+        [
+          {
+            name: "metadata",
+            value: JSON.stringify([
+              { displayName: "대표 이미지", categoryId: category.id },
+            ]),
+          },
+        ],
+      );
+      const res = await app.inject({
+        method: "POST",
+        url: "/assets/upload",
+        headers: {
+          cookie: authCookie,
+          "content-type": `multipart/form-data; boundary=${boundary}`,
+        },
+        payload,
+      });
+
+      expect(res.statusCode).toBe(201);
+      const asset = res.json().assets[0];
+      expect(asset).toMatchObject({
+        displayName: "대표 이미지",
+        category: { id: category.id, name: "Upload Target" },
+      });
     });
 
     it("업로드 후 반환된 /uploads URL로 정적 접근 가능", async () => {
       const boundary = "testboundary";
       const payload = buildMultipart(
-        [{ fieldName: "files", fileName: "served.png", content: TINY_PNG, mimeType: "image/png" }],
+        [
+          {
+            fieldName: "files",
+            fileName: "served.png",
+            content: TINY_PNG,
+            mimeType: "image/png",
+          },
+        ],
         boundary,
       );
       const uploadRes = await app.inject({
@@ -224,7 +451,14 @@ describe("Asset Routes", () => {
     it("안전한 SVG 업로드 → 201", async () => {
       const boundary = "testboundary";
       const payload = buildMultipart(
-        [{ fieldName: "files", fileName: "safe.svg", content: SAFE_SVG, mimeType: "image/svg+xml" }],
+        [
+          {
+            fieldName: "files",
+            fileName: "safe.svg",
+            content: SAFE_SVG,
+            mimeType: "image/svg+xml",
+          },
+        ],
         boundary,
       );
       const res = await app.inject({
@@ -245,7 +479,14 @@ describe("Asset Routes", () => {
     it("active content가 포함된 SVG → 400", async () => {
       const boundary = "testboundary";
       const payload = buildMultipart(
-        [{ fieldName: "files", fileName: "unsafe.svg", content: UNSAFE_SVG, mimeType: "image/svg+xml" }],
+        [
+          {
+            fieldName: "files",
+            fileName: "unsafe.svg",
+            content: UNSAFE_SVG,
+            mimeType: "image/svg+xml",
+          },
+        ],
         boundary,
       );
       const res = await app.inject({
@@ -263,7 +504,14 @@ describe("Asset Routes", () => {
     it("엔티티 인코딩된 scriptable URL이 있는 SVG → 400", async () => {
       const boundary = "testboundary";
       const payload = buildMultipart(
-        [{ fieldName: "files", fileName: "encoded-unsafe.svg", content: ENCODED_UNSAFE_SVG, mimeType: "image/svg+xml" }],
+        [
+          {
+            fieldName: "files",
+            fileName: "encoded-unsafe.svg",
+            content: ENCODED_UNSAFE_SVG,
+            mimeType: "image/svg+xml",
+          },
+        ],
         boundary,
       );
       const res = await app.inject({
@@ -281,7 +529,14 @@ describe("Asset Routes", () => {
     it("RIFF 기반 비-WebP 파일을 WebP로 위장하면 → 400", async () => {
       const boundary = "testboundary";
       const payload = buildMultipart(
-        [{ fieldName: "files", fileName: "fake.webp", content: FAKE_WEBP, mimeType: "image/webp" }],
+        [
+          {
+            fieldName: "files",
+            fileName: "fake.webp",
+            content: FAKE_WEBP,
+            mimeType: "image/webp",
+          },
+        ],
         boundary,
       );
       const res = await app.inject({
@@ -299,7 +554,14 @@ describe("Asset Routes", () => {
     it("허용되지 않은 MIME → 400", async () => {
       const boundary = "testboundary";
       const payload = buildMultipart(
-        [{ fieldName: "files", fileName: "test.txt", content: Buffer.from("hello"), mimeType: "text/plain" }],
+        [
+          {
+            fieldName: "files",
+            fileName: "test.txt",
+            content: Buffer.from("hello"),
+            mimeType: "text/plain",
+          },
+        ],
         boundary,
       );
       const res = await app.inject({
@@ -333,7 +595,14 @@ describe("Asset Routes", () => {
       const boundary = "testboundary";
       const largeBuffer = Buffer.alloc(11 * 1024 * 1024); // 11MB
       const payload = buildMultipart(
-        [{ fieldName: "files", fileName: "big.png", content: largeBuffer, mimeType: "image/png" }],
+        [
+          {
+            fieldName: "files",
+            fileName: "big.png",
+            content: largeBuffer,
+            mimeType: "image/png",
+          },
+        ],
         boundary,
       );
       const res = await app.inject({
@@ -364,6 +633,7 @@ describe("Asset Routes", () => {
       expect(body.url).toBe(`/uploads/${asset.storageKey}`);
       expect(body.width).toBe(800);
       expect(body.height).toBe(600);
+      expect(body.category.id).toBe(asset.categoryId);
     });
 
     it("없는 id → 404", async () => {
@@ -372,6 +642,71 @@ describe("Asset Routes", () => {
         url: "/assets/999999",
       });
       expect(res.statusCode).toBe(404);
+    });
+  });
+
+  // ===== PATCH /assets/:id =====
+
+  describe("PATCH /assets/:id", () => {
+    it("별명과 카테고리 수정 → 200", async () => {
+      const category = await seedAssetCategory({ name: "Updated Category" });
+      const asset = await seedAsset();
+
+      const res = await app.inject({
+        method: "PATCH",
+        url: `/assets/${asset.id}`,
+        headers: { cookie: authCookie },
+        payload: { displayName: "수정된 별명", categoryId: category.id },
+      });
+
+      expect(res.statusCode).toBe(200);
+      expect(res.json()).toMatchObject({
+        id: asset.id,
+        displayName: "수정된 별명",
+        category: { id: category.id, name: "Updated Category" },
+      });
+    });
+
+    it("없는 카테고리로 수정하면 → 400", async () => {
+      const asset = await seedAsset();
+      const res = await app.inject({
+        method: "PATCH",
+        url: `/assets/${asset.id}`,
+        headers: { cookie: authCookie },
+        payload: { categoryId: 999999 },
+      });
+
+      expect(res.statusCode).toBe(400);
+    });
+  });
+
+  // ===== PATCH /assets/bulk/category =====
+
+  describe("PATCH /assets/bulk/category", () => {
+    it("벌크 카테고리 변경 → 204", async () => {
+      const category = await seedAssetCategory({ name: "Bulk Target" });
+      const [a1, a2] = await Promise.all([seedAsset(), seedAsset()]);
+
+      const res = await app.inject({
+        method: "PATCH",
+        url: "/assets/bulk/category",
+        headers: { cookie: authCookie },
+        payload: { ids: [a1.id, a2.id], categoryId: category.id },
+      });
+
+      expect(res.statusCode).toBe(204);
+
+      const check = await app.inject({
+        method: "GET",
+        url: `/assets?categoryId=${category.id}`,
+        headers: { cookie: authCookie },
+      });
+      expect(
+        check
+          .json()
+          .data.map((asset: { id: number }) => asset.id)
+          .sort(),
+      ).toEqual([a1.id, a2.id].sort());
     });
   });
 
@@ -462,13 +797,22 @@ describe("Asset Routes", () => {
       expect(res.statusCode).toBe(204);
 
       // 삭제된 id 조회 → 404
-      const check1 = await app.inject({ method: "GET", url: `/assets/${a1.id}` });
-      const check2 = await app.inject({ method: "GET", url: `/assets/${a2.id}` });
+      const check1 = await app.inject({
+        method: "GET",
+        url: `/assets/${a1.id}`,
+      });
+      const check2 = await app.inject({
+        method: "GET",
+        url: `/assets/${a2.id}`,
+      });
       expect(check1.statusCode).toBe(404);
       expect(check2.statusCode).toBe(404);
 
       // 삭제 안 된 id는 유지
-      const check3 = await app.inject({ method: "GET", url: `/assets/${a3.id}` });
+      const check3 = await app.inject({
+        method: "GET",
+        url: `/assets/${a3.id}`,
+      });
       expect(check3.statusCode).toBe(200);
     });
 


### PR DESCRIPTION
## Summary

Closes #124

Adds asset display names and flat asset categories, including protected default categories, metadata-aware uploads, asset filtering/search, and asset metadata update APIs.

## Changes

| File | Change |
|------|--------|
| `src/db/schema/assets.ts`, `drizzle/0012_asset_categories.sql` | Add `asset_category_tb`, `asset_tb.display_name`, `asset_tb.category_id`, default category seed/backfill migration |
| `src/routes/assets/asset.route.ts` | Add category CRUD, asset metadata patch, bulk category patch, and multipart metadata parsing |
| `src/routes/assets/asset.service.ts` | Implement default category enforcement, category protection/delete reassignment, list filters, and metadata updates |
| `src/routes/assets/asset.schema.ts` | Extend asset/category request and response schemas |
| `test/routes/assets.test.ts`, `test/helpers/seed.ts` | Cover defaults, category protection, delete reassignment, upload metadata, filtering/search, and patch APIs |

